### PR TITLE
Update import on bool.go

### DIFF
--- a/bool.go
+++ b/bool.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 
-	"github.com/nullbio/null/convert"
+	"gopkg.in/nullbio/null.v6/convert"
 )
 
 // Bool is a nullable bool.


### PR DESCRIPTION
Switch import to use "gopkg.in/nullbio/null.v6/convert" instead of non-versioned github import, so that build does not require both versions.