### PR TITLE
Fix for uint64 value bigger than 1<<63

### DIFF
--- a/uint64.go
+++ b/uint64.go
@@ -117,6 +117,11 @@ func (u Uint64) Value() (driver.Value, error) {
 	if !u.Valid {
 		return nil, nil
 	}
+
+	if u.Uint64 >= 1<<63 {
+		return strconv.FormatUint(u.Uint64, 10), nil
+	}
+
 	return int64(u.Uint64), nil
 }
 


### PR DESCRIPTION
Hi, uint64 bigger than 1<<63 - 1 overflows int64