### PR TITLE
Conform null.Bytes to standard JSON handling of []byte

### DIFF
--- a/bytes.go
+++ b/bytes.go
@@ -47,19 +47,19 @@ func (b *Bytes) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	var s string
-	if err := json.Unmarshal(data, &s); err != nil {
+	var bv []byte
+	if err := json.Unmarshal(data, &bv); err != nil {
 		return err
 	}
 
-	b.Bytes = []byte(s)
+	b.Bytes = bv
 	b.Valid = true
 	return nil
 }
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (b *Bytes) UnmarshalText(text []byte) error {
-	if text == nil || len(text) == 0 {
+	if len(text) == 0 {
 		b.Bytes = nil
 		b.Valid = false
 	} else {
@@ -72,10 +72,10 @@ func (b *Bytes) UnmarshalText(text []byte) error {
 
 // MarshalJSON implements json.Marshaler.
 func (b Bytes) MarshalJSON() ([]byte, error) {
-	if len(b.Bytes) == 0 || b.Bytes == nil {
+	if len(b.Bytes) == 0 {
 		return NullBytes, nil
 	}
-	return b.Bytes, nil
+	return json.Marshal(b.Bytes)
 }
 
 // MarshalText implements encoding.TextMarshaler.

--- a/bytes_test.go
+++ b/bytes_test.go
@@ -7,7 +7,8 @@ import (
 )
 
 var (
-	bytesJSON = []byte(`"hello"`)
+	bytesJSON    = []byte(`"hello"`)
+	b64BytesJSON = []byte(`"aGVsbG8="`)
 )
 
 func TestBytesFrom(t *testing.T) {
@@ -37,7 +38,7 @@ func TestBytesFromPtr(t *testing.T) {
 
 func TestUnmarshalBytes(t *testing.T) {
 	var i Bytes
-	err := json.Unmarshal(bytesJSON, &i)
+	err := json.Unmarshal(b64BytesJSON, &i)
 	maybePanic(err)
 	assertBytes(t, i, "[]byte json")
 
@@ -70,10 +71,10 @@ func TestTextUnmarshalBytes(t *testing.T) {
 }
 
 func TestMarshalBytes(t *testing.T) {
-	i := BytesFrom([]byte(`"hello"`))
+	i := BytesFrom([]byte(`hello`))
 	data, err := json.Marshal(i)
 	maybePanic(err)
-	assertJSONEquals(t, data, `"hello"`, "non-empty json marshal")
+	assertJSONEquals(t, data, string(b64BytesJSON), "non-empty json marshal")
 
 	// invalid values should be encoded as null
 	null := NewBytes(nil, false)

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
+github.com/friendsofgo/errors v0.9.2 h1:X6NYxef4efCBdwI7BgS820zFaN7Cphrmb+Pljdzjtgk=
 github.com/friendsofgo/errors v0.9.2/go.mod h1:yCvFW5AkDIL9qn7suHVLiI/gH228n7PC4Pn44IGoTOI=
+github.com/gofrs/uuid v3.2.0+incompatible h1:y12jRkkFxsd7GpqdSZ+/KCs/fJbqpEXSGd4+jfEaewE=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/volatiletech/inflect v0.0.1 h1:2a6FcMQyhmPZcLa+uet3VJ8gLn/9svWhJxJYwvE8KsU=
 github.com/volatiletech/inflect v0.0.1/go.mod h1:IBti31tG6phkHitLlr5j7shC5SOo//x0AjDzaJU1PLA=


### PR DESCRIPTION
It doesn't seem like issues can be opened in this repo, so hoping to have a discussion based on this PR.

The way `null.Bytes` marshals and unmarshals to JSON is not what most people would expect. Like the rest of the null types, when Valid, it should behave like the standard serialization of `[]byte`, namely to base64 encode it.

This PR makes the adjustment, though it's probably considered a breaking change and should likely create a new major version, or we could create another type that has this behavior.