### PR TITLE
Add IsSet() to all types

### DIFF
--- a/bool.go
+++ b/bool.go
@@ -126,12 +126,11 @@ func (b Bool) IsZero() bool {
 
 // Scan implements the Scanner interface.
 func (b *Bool) Scan(value interface{}) error {
-	b.set = true
 	if value == nil {
-		b.Bool, b.Valid = false, false
+		b.Bool, b.Valid, b.set = false, false, true
 		return nil
 	}
-	b.Valid = true
+	b.Valid, b.set = true, true
 	return convert.ConvertAssign(&b.Bool, value)
 }
 

--- a/bool.go
+++ b/bool.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 
-	"github.com/volatiletech/null/v8/convert"
+	"github.com/razor-1/null/v9/convert"
 )
 
 // Bool is a nullable bool.
@@ -62,6 +62,7 @@ func (b *Bool) UnmarshalJSON(data []byte) error {
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (b *Bool) UnmarshalText(text []byte) error {
+	b.set = true
 	if text == nil || len(text) == 0 {
 		b.Valid = false
 		return nil
@@ -107,6 +108,7 @@ func (b Bool) MarshalText() ([]byte, error) {
 func (b *Bool) SetValid(v bool) {
 	b.Bool = v
 	b.Valid = true
+	b.set = true
 }
 
 // Ptr returns a pointer to this Bool's value, or a nil pointer if this Bool is null.
@@ -124,6 +126,7 @@ func (b Bool) IsZero() bool {
 
 // Scan implements the Scanner interface.
 func (b *Bool) Scan(value interface{}) error {
+	b.set = true
 	if value == nil {
 		b.Bool, b.Valid = false, false
 		return nil

--- a/bool.go
+++ b/bool.go
@@ -127,7 +127,7 @@ func (b Bool) IsZero() bool {
 // Scan implements the Scanner interface.
 func (b *Bool) Scan(value interface{}) error {
 	if value == nil {
-		b.Bool, b.Valid, b.set = false, false, true
+		b.Bool, b.Valid, b.set = false, false, false
 		return nil
 	}
 	b.Valid, b.set = true, true

--- a/bool.go
+++ b/bool.go
@@ -13,31 +13,39 @@ import (
 type Bool struct {
 	Bool  bool
 	Valid bool
+	set   bool
 }
 
 // NewBool creates a new Bool
-func NewBool(b bool, valid bool) Bool {
+func NewBool(b bool, valid, set bool) Bool {
 	return Bool{
 		Bool:  b,
 		Valid: valid,
+		set:   set,
 	}
 }
 
 // BoolFrom creates a new Bool that will always be valid.
 func BoolFrom(b bool) Bool {
-	return NewBool(b, true)
+	return NewBool(b, true, true)
 }
 
 // BoolFromPtr creates a new Bool that will be null if f is nil.
 func BoolFromPtr(b *bool) Bool {
 	if b == nil {
-		return NewBool(false, false)
+		return NewBool(false, false, true)
 	}
-	return NewBool(*b, true)
+	return NewBool(*b, true, true)
+}
+
+func (b Bool) IsSet() bool {
+	return b.set
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (b *Bool) UnmarshalJSON(data []byte) error {
+	b.set = true
+
 	if bytes.Equal(data, NullBytes) {
 		b.Bool = false
 		b.Valid = false

--- a/bool.go
+++ b/bool.go
@@ -17,25 +17,25 @@ type Bool struct {
 }
 
 // NewBool creates a new Bool
-func NewBool(b bool, valid, set bool) Bool {
+func NewBool(b, valid bool) Bool {
 	return Bool{
 		Bool:  b,
 		Valid: valid,
-		Set:   set,
+		Set:   true,
 	}
 }
 
 // BoolFrom creates a new Bool that will always be valid.
 func BoolFrom(b bool) Bool {
-	return NewBool(b, true, true)
+	return NewBool(b, true)
 }
 
 // BoolFromPtr creates a new Bool that will be null if f is nil.
 func BoolFromPtr(b *bool) Bool {
 	if b == nil {
-		return NewBool(false, false, true)
+		return NewBool(false, false)
 	}
-	return NewBool(*b, true, true)
+	return NewBool(*b, true)
 }
 
 func (b Bool) IsSet() bool {

--- a/bool.go
+++ b/bool.go
@@ -13,7 +13,7 @@ import (
 type Bool struct {
 	Bool  bool
 	Valid bool
-	set   bool
+	Set   bool
 }
 
 // NewBool creates a new Bool
@@ -21,7 +21,7 @@ func NewBool(b bool, valid, set bool) Bool {
 	return Bool{
 		Bool:  b,
 		Valid: valid,
-		set:   set,
+		Set:   set,
 	}
 }
 
@@ -39,12 +39,12 @@ func BoolFromPtr(b *bool) Bool {
 }
 
 func (b Bool) IsSet() bool {
-	return b.set
+	return b.Set
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (b *Bool) UnmarshalJSON(data []byte) error {
-	b.set = true
+	b.Set = true
 
 	if bytes.Equal(data, NullBytes) {
 		b.Bool = false
@@ -62,7 +62,7 @@ func (b *Bool) UnmarshalJSON(data []byte) error {
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (b *Bool) UnmarshalText(text []byte) error {
-	b.set = true
+	b.Set = true
 	if text == nil || len(text) == 0 {
 		b.Valid = false
 		return nil
@@ -108,7 +108,7 @@ func (b Bool) MarshalText() ([]byte, error) {
 func (b *Bool) SetValid(v bool) {
 	b.Bool = v
 	b.Valid = true
-	b.set = true
+	b.Set = true
 }
 
 // Ptr returns a pointer to this Bool's value, or a nil pointer if this Bool is null.
@@ -127,10 +127,10 @@ func (b Bool) IsZero() bool {
 // Scan implements the Scanner interface.
 func (b *Bool) Scan(value interface{}) error {
 	if value == nil {
-		b.Bool, b.Valid, b.set = false, false, false
+		b.Bool, b.Valid, b.Set = false, false, false
 		return nil
 	}
-	b.Valid, b.set = true, true
+	b.Valid, b.Set = true, true
 	return convert.ConvertAssign(&b.Bool, value)
 }
 

--- a/bool_test.go
+++ b/bool_test.go
@@ -6,8 +6,7 @@ import (
 )
 
 var (
-	boolJSON  = []byte(`true`)
-	falseJSON = []byte(`false`)
+	boolJSON = []byte(`true`)
 )
 
 func TestBoolFrom(t *testing.T) {
@@ -31,13 +30,8 @@ func TestBoolFromPtr(t *testing.T) {
 }
 
 func TestUnmarshalBool(t *testing.T) {
-	var b Bool
-	err := json.Unmarshal(boolJSON, &b)
-	maybePanic(err)
-	assertBool(t, b, "bool json")
-
 	var null Bool
-	err = json.Unmarshal(nullJSON, &null)
+	err := json.Unmarshal(nullJSON, &null)
 	maybePanic(err)
 	assertNullBool(t, null, "null json")
 	if !null.Set {
@@ -88,13 +82,13 @@ func TestMarshalBool(t *testing.T) {
 	maybePanic(err)
 	assertJSONEquals(t, data, "true", "non-empty json marshal")
 
-	zero := NewBool(false, true, true)
+	zero := NewBool(false, true)
 	data, err = json.Marshal(zero)
 	maybePanic(err)
 	assertJSONEquals(t, data, "false", "zero json marshal")
 
 	// invalid values should be encoded as null
-	null := NewBool(false, false, true)
+	null := NewBool(false, false)
 	data, err = json.Marshal(null)
 	maybePanic(err)
 	assertJSONEquals(t, data, "null", "null json marshal")
@@ -106,13 +100,13 @@ func TestMarshalBoolText(t *testing.T) {
 	maybePanic(err)
 	assertJSONEquals(t, data, "true", "non-empty text marshal")
 
-	zero := NewBool(false, true, true)
+	zero := NewBool(false, true)
 	data, err = zero.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "false", "zero text marshal")
 
 	// invalid values should be encoded as null
-	null := NewBool(false, false, true)
+	null := NewBool(false, false)
 	data, err = null.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "null text marshal")
@@ -125,7 +119,7 @@ func TestBoolPointer(t *testing.T) {
 		t.Errorf("bad %s bool: %#v ≠ %v\n", "pointer", ptr, true)
 	}
 
-	null := NewBool(false, false, true)
+	null := NewBool(false, false)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s bool: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -138,19 +132,19 @@ func TestBoolIsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	null := NewBool(false, false, true)
+	null := NewBool(false, false)
 	if !null.IsZero() {
 		t.Errorf("IsZero() should be true")
 	}
 
-	zero := NewBool(false, true, true)
+	zero := NewBool(false, true)
 	if zero.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
 }
 
 func TestBoolSetValid(t *testing.T) {
-	change := NewBool(false, false, true)
+	change := NewBool(false, false)
 	assertNullBool(t, change, "SetValid()")
 	change.SetValid(true)
 	assertBool(t, change, "SetValid()")

--- a/bool_test.go
+++ b/bool_test.go
@@ -40,6 +40,9 @@ func TestUnmarshalBool(t *testing.T) {
 	err = json.Unmarshal(nullJSON, &null)
 	maybePanic(err)
 	assertNullBool(t, null, "null json")
+	if !null.set {
+		t.Error("should be set", err)
+	}
 
 	var badType Bool
 	err = json.Unmarshal(intJSON, &badType)
@@ -85,13 +88,13 @@ func TestMarshalBool(t *testing.T) {
 	maybePanic(err)
 	assertJSONEquals(t, data, "true", "non-empty json marshal")
 
-	zero := NewBool(false, true)
+	zero := NewBool(false, true, true)
 	data, err = json.Marshal(zero)
 	maybePanic(err)
 	assertJSONEquals(t, data, "false", "zero json marshal")
 
 	// invalid values should be encoded as null
-	null := NewBool(false, false)
+	null := NewBool(false, false, true)
 	data, err = json.Marshal(null)
 	maybePanic(err)
 	assertJSONEquals(t, data, "null", "null json marshal")
@@ -103,13 +106,13 @@ func TestMarshalBoolText(t *testing.T) {
 	maybePanic(err)
 	assertJSONEquals(t, data, "true", "non-empty text marshal")
 
-	zero := NewBool(false, true)
+	zero := NewBool(false, true, true)
 	data, err = zero.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "false", "zero text marshal")
 
 	// invalid values should be encoded as null
-	null := NewBool(false, false)
+	null := NewBool(false, false, true)
 	data, err = null.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "null text marshal")
@@ -122,7 +125,7 @@ func TestBoolPointer(t *testing.T) {
 		t.Errorf("bad %s bool: %#v ≠ %v\n", "pointer", ptr, true)
 	}
 
-	null := NewBool(false, false)
+	null := NewBool(false, false, true)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s bool: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -135,19 +138,19 @@ func TestBoolIsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	null := NewBool(false, false)
+	null := NewBool(false, false, true)
 	if !null.IsZero() {
 		t.Errorf("IsZero() should be true")
 	}
 
-	zero := NewBool(false, true)
+	zero := NewBool(false, true, true)
 	if zero.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
 }
 
 func TestBoolSetValid(t *testing.T) {
-	change := NewBool(false, false)
+	change := NewBool(false, false, true)
 	assertNullBool(t, change, "SetValid()")
 	change.SetValid(true)
 	assertBool(t, change, "SetValid()")

--- a/bool_test.go
+++ b/bool_test.go
@@ -40,8 +40,8 @@ func TestUnmarshalBool(t *testing.T) {
 	err = json.Unmarshal(nullJSON, &null)
 	maybePanic(err)
 	assertNullBool(t, null, "null json")
-	if !null.set {
-		t.Error("should be set", err)
+	if !null.Set {
+		t.Error("should be Set", err)
 	}
 
 	var badType Bool

--- a/byte.go
+++ b/byte.go
@@ -119,21 +119,18 @@ func (b Byte) IsZero() bool {
 
 // Scan implements the Scanner interface.
 func (b *Byte) Scan(value interface{}) error {
-	b.set = true
 	if value == nil {
-		b.Byte, b.Valid = 0, false
+		b.Byte, b.Valid, b.set = 0, false, false
 		return nil
 	}
 
 	val := value.(string)
 	if len(val) == 0 {
-		b.Valid = false
-		b.Byte = 0
+		b.Byte, b.Valid, b.set = 0, false, false
 		return nil
 	}
 
-	b.Valid = true
-	b.Byte = byte(val[0])
+	b.Byte, b.Valid, b.set = val[0], true, true
 	return nil
 }
 

--- a/byte.go
+++ b/byte.go
@@ -66,6 +66,7 @@ func (b *Byte) UnmarshalJSON(data []byte) error {
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (b *Byte) UnmarshalText(text []byte) error {
+	b.set = true
 	if text == nil || len(text) == 0 {
 		b.Valid = false
 		return nil
@@ -100,6 +101,7 @@ func (b Byte) MarshalText() ([]byte, error) {
 func (b *Byte) SetValid(n byte) {
 	b.Byte = n
 	b.Valid = true
+	b.set = true
 }
 
 // Ptr returns a pointer to this Byte's value, or a nil pointer if this Byte is null.
@@ -117,6 +119,7 @@ func (b Byte) IsZero() bool {
 
 // Scan implements the Scanner interface.
 func (b *Byte) Scan(value interface{}) error {
+	b.set = true
 	if value == nil {
 		b.Byte, b.Valid = 0, false
 		return nil

--- a/byte.go
+++ b/byte.go
@@ -11,31 +11,39 @@ import (
 type Byte struct {
 	Byte  byte
 	Valid bool
+	set   bool
 }
 
 // NewByte creates a new Byte
-func NewByte(b byte, valid bool) Byte {
+func NewByte(b byte, valid, set bool) Byte {
 	return Byte{
 		Byte:  b,
 		Valid: valid,
+		set:   set,
 	}
 }
 
 // ByteFrom creates a new Byte that will always be valid.
 func ByteFrom(b byte) Byte {
-	return NewByte(b, true)
+	return NewByte(b, true, true)
 }
 
 // ByteFromPtr creates a new Byte that be null if i is nil.
 func ByteFromPtr(b *byte) Byte {
 	if b == nil {
-		return NewByte(0, false)
+		return NewByte(0, false, true)
 	}
-	return NewByte(*b, true)
+	return NewByte(*b, true, true)
+}
+
+func (b Byte) IsSet() bool {
+	return b.set
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (b *Byte) UnmarshalJSON(data []byte) error {
+	b.set = true
+
 	if len(data) == 0 || bytes.Equal(data, NullBytes) {
 		b.Valid = false
 		b.Byte = 0

--- a/byte.go
+++ b/byte.go
@@ -15,25 +15,25 @@ type Byte struct {
 }
 
 // NewByte creates a new Byte
-func NewByte(b byte, valid, set bool) Byte {
+func NewByte(b byte, valid bool) Byte {
 	return Byte{
 		Byte:  b,
 		Valid: valid,
-		Set:   set,
+		Set:   true,
 	}
 }
 
 // ByteFrom creates a new Byte that will always be valid.
 func ByteFrom(b byte) Byte {
-	return NewByte(b, true, true)
+	return NewByte(b, true)
 }
 
 // ByteFromPtr creates a new Byte that be null if i is nil.
 func ByteFromPtr(b *byte) Byte {
 	if b == nil {
-		return NewByte(0, false, true)
+		return NewByte(0, false)
 	}
-	return NewByte(*b, true, true)
+	return NewByte(*b, true)
 }
 
 func (b Byte) IsSet() bool {

--- a/byte.go
+++ b/byte.go
@@ -11,7 +11,7 @@ import (
 type Byte struct {
 	Byte  byte
 	Valid bool
-	set   bool
+	Set   bool
 }
 
 // NewByte creates a new Byte
@@ -19,7 +19,7 @@ func NewByte(b byte, valid, set bool) Byte {
 	return Byte{
 		Byte:  b,
 		Valid: valid,
-		set:   set,
+		Set:   set,
 	}
 }
 
@@ -37,12 +37,12 @@ func ByteFromPtr(b *byte) Byte {
 }
 
 func (b Byte) IsSet() bool {
-	return b.set
+	return b.Set
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (b *Byte) UnmarshalJSON(data []byte) error {
-	b.set = true
+	b.Set = true
 
 	if len(data) == 0 || bytes.Equal(data, NullBytes) {
 		b.Valid = false
@@ -66,7 +66,7 @@ func (b *Byte) UnmarshalJSON(data []byte) error {
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (b *Byte) UnmarshalText(text []byte) error {
-	b.set = true
+	b.Set = true
 	if text == nil || len(text) == 0 {
 		b.Valid = false
 		return nil
@@ -101,7 +101,7 @@ func (b Byte) MarshalText() ([]byte, error) {
 func (b *Byte) SetValid(n byte) {
 	b.Byte = n
 	b.Valid = true
-	b.set = true
+	b.Set = true
 }
 
 // Ptr returns a pointer to this Byte's value, or a nil pointer if this Byte is null.
@@ -120,17 +120,17 @@ func (b Byte) IsZero() bool {
 // Scan implements the Scanner interface.
 func (b *Byte) Scan(value interface{}) error {
 	if value == nil {
-		b.Byte, b.Valid, b.set = 0, false, false
+		b.Byte, b.Valid, b.Set = 0, false, false
 		return nil
 	}
 
 	val := value.(string)
 	if len(val) == 0 {
-		b.Byte, b.Valid, b.set = 0, false, false
+		b.Byte, b.Valid, b.Set = 0, false, false
 		return nil
 	}
 
-	b.Byte, b.Valid, b.set = val[0], true, true
+	b.Byte, b.Valid, b.Set = val[0], true, true
 	return nil
 }
 

--- a/byte_test.go
+++ b/byte_test.go
@@ -34,8 +34,8 @@ func TestUnmarshalByte(t *testing.T) {
 	err := json.Unmarshal(nullJSON, &null)
 	maybePanic(err)
 	assertNullByte(t, null, "null json")
-	if !null.set {
-		t.Error("expected set to be true")
+	if !null.Set {
+		t.Error("expected Set to be true")
 	}
 
 	var badType Byte

--- a/byte_test.go
+++ b/byte_test.go
@@ -5,10 +5,6 @@ import (
 	"testing"
 )
 
-var (
-	byteJSON = []byte(`"b"`)
-)
-
 func TestByteFrom(t *testing.T) {
 	i := ByteFrom('b')
 	assertByte(t, i, "ByteFrom()")
@@ -80,7 +76,7 @@ func TestMarshalByte(t *testing.T) {
 	assertJSONEquals(t, data, `"b"`, "non-empty json marshal")
 
 	// invalid values should be encoded as null
-	null := NewByte(0, false, true)
+	null := NewByte(0, false)
 	data, err = json.Marshal(null)
 	maybePanic(err)
 	assertJSONEquals(t, data, "null", "null json marshal")
@@ -93,7 +89,7 @@ func TestMarshalByteText(t *testing.T) {
 	assertJSONEquals(t, data, "b", "non-empty text marshal")
 
 	// invalid values should be encoded as null
-	null := NewByte(0, false, true)
+	null := NewByte(0, false)
 	data, err = null.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "null text marshal")
@@ -106,7 +102,7 @@ func TestBytePointer(t *testing.T) {
 		t.Errorf("bad %s int: %#v ≠ %d\n", "pointer", ptr, 'b')
 	}
 
-	null := NewByte(0, false, true)
+	null := NewByte(0, false)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s int: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -119,19 +115,19 @@ func TestByteIsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	null := NewByte(0, false, true)
+	null := NewByte(0, false)
 	if !null.IsZero() {
 		t.Errorf("IsZero() should be true")
 	}
 
-	zero := NewByte(0, true, true)
+	zero := NewByte(0, true)
 	if zero.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
 }
 
 func TestByteSetValid(t *testing.T) {
-	change := NewByte(0, false, true)
+	change := NewByte(0, false)
 	assertNullByte(t, change, "SetValid()")
 	change.SetValid('b')
 	assertByte(t, change, "SetValid()")

--- a/byte_test.go
+++ b/byte_test.go
@@ -34,6 +34,9 @@ func TestUnmarshalByte(t *testing.T) {
 	err := json.Unmarshal(nullJSON, &null)
 	maybePanic(err)
 	assertNullByte(t, null, "null json")
+	if !null.set {
+		t.Error("expected set to be true")
+	}
 
 	var badType Byte
 	err = json.Unmarshal(boolJSON, &badType)
@@ -77,7 +80,7 @@ func TestMarshalByte(t *testing.T) {
 	assertJSONEquals(t, data, `"b"`, "non-empty json marshal")
 
 	// invalid values should be encoded as null
-	null := NewByte(0, false)
+	null := NewByte(0, false, true)
 	data, err = json.Marshal(null)
 	maybePanic(err)
 	assertJSONEquals(t, data, "null", "null json marshal")
@@ -90,7 +93,7 @@ func TestMarshalByteText(t *testing.T) {
 	assertJSONEquals(t, data, "b", "non-empty text marshal")
 
 	// invalid values should be encoded as null
-	null := NewByte(0, false)
+	null := NewByte(0, false, true)
 	data, err = null.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "null text marshal")
@@ -103,7 +106,7 @@ func TestBytePointer(t *testing.T) {
 		t.Errorf("bad %s int: %#v ≠ %d\n", "pointer", ptr, 'b')
 	}
 
-	null := NewByte(0, false)
+	null := NewByte(0, false, true)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s int: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -116,19 +119,19 @@ func TestByteIsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	null := NewByte(0, false)
+	null := NewByte(0, false, true)
 	if !null.IsZero() {
 		t.Errorf("IsZero() should be true")
 	}
 
-	zero := NewByte(0, true)
+	zero := NewByte(0, true, true)
 	if zero.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
 }
 
 func TestByteSetValid(t *testing.T) {
-	change := NewByte(0, false)
+	change := NewByte(0, false, true)
 	assertNullByte(t, change, "SetValid()")
 	change.SetValid('b')
 	assertByte(t, change, "SetValid()")

--- a/bytes.go
+++ b/bytes.go
@@ -47,19 +47,19 @@ func (b *Bytes) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	var s string
-	if err := json.Unmarshal(data, &s); err != nil {
+	var bv []byte
+	if err := json.Unmarshal(data, &bv); err != nil {
 		return err
 	}
 
-	b.Bytes = []byte(s)
+	b.Bytes = bv
 	b.Valid = true
 	return nil
 }
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (b *Bytes) UnmarshalText(text []byte) error {
-	if text == nil || len(text) == 0 {
+	if len(text) == 0 {
 		b.Bytes = nil
 		b.Valid = false
 	} else {
@@ -72,10 +72,10 @@ func (b *Bytes) UnmarshalText(text []byte) error {
 
 // MarshalJSON implements json.Marshaler.
 func (b Bytes) MarshalJSON() ([]byte, error) {
-	if len(b.Bytes) == 0 || b.Bytes == nil {
+	if len(b.Bytes) == 0 {
 		return NullBytes, nil
 	}
-	return b.Bytes, nil
+	return json.Marshal(b.Bytes)
 }
 
 // MarshalText implements encoding.TextMarshaler.

--- a/bytes.go
+++ b/bytes.go
@@ -19,25 +19,25 @@ type Bytes struct {
 }
 
 // NewBytes creates a new Bytes
-func NewBytes(b []byte, valid, set bool) Bytes {
+func NewBytes(b []byte, valid bool) Bytes {
 	return Bytes{
 		Bytes: b,
 		Valid: valid,
-		Set:   set,
+		Set:   true,
 	}
 }
 
 // BytesFrom creates a new Bytes that will be invalid if nil.
 func BytesFrom(b []byte) Bytes {
-	return NewBytes(b, b != nil, true)
+	return NewBytes(b, b != nil)
 }
 
 // BytesFromPtr creates a new Bytes that will be invalid if nil.
 func BytesFromPtr(b *[]byte) Bytes {
 	if b == nil {
-		return NewBytes(nil, false, true)
+		return NewBytes(nil, false)
 	}
-	n := NewBytes(*b, true, true)
+	n := NewBytes(*b, true)
 	return n
 }
 

--- a/bytes.go
+++ b/bytes.go
@@ -15,7 +15,7 @@ var NullBytes = []byte("null")
 type Bytes struct {
 	Bytes []byte
 	Valid bool
-	set   bool
+	Set   bool
 }
 
 // NewBytes creates a new Bytes
@@ -23,7 +23,7 @@ func NewBytes(b []byte, valid, set bool) Bytes {
 	return Bytes{
 		Bytes: b,
 		Valid: valid,
-		set:   set,
+		Set:   set,
 	}
 }
 
@@ -42,12 +42,12 @@ func BytesFromPtr(b *[]byte) Bytes {
 }
 
 func (b Bytes) IsSet() bool {
-	return b.set
+	return b.Set
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (b *Bytes) UnmarshalJSON(data []byte) error {
-	b.set = true
+	b.Set = true
 
 	if bytes.Equal(data, NullBytes) {
 		b.Valid = false
@@ -67,7 +67,7 @@ func (b *Bytes) UnmarshalJSON(data []byte) error {
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (b *Bytes) UnmarshalText(text []byte) error {
-	b.set = true
+	b.Set = true
 	if len(text) == 0 {
 		b.Bytes = nil
 		b.Valid = false
@@ -99,7 +99,7 @@ func (b Bytes) MarshalText() ([]byte, error) {
 func (b *Bytes) SetValid(n []byte) {
 	b.Bytes = n
 	b.Valid = true
-	b.set = true
+	b.Set = true
 }
 
 // Ptr returns a pointer to this Bytes's value, or a nil pointer if this Bytes is null.
@@ -118,10 +118,10 @@ func (b Bytes) IsZero() bool {
 // Scan implements the Scanner interface.
 func (b *Bytes) Scan(value interface{}) error {
 	if value == nil {
-		b.Bytes, b.Valid, b.set = nil, false, false
+		b.Bytes, b.Valid, b.Set = nil, false, false
 		return nil
 	}
-	b.Valid, b.set = true, true
+	b.Valid, b.Set = true, true
 	return convert.ConvertAssign(&b.Bytes, value)
 }
 

--- a/bytes.go
+++ b/bytes.go
@@ -117,12 +117,11 @@ func (b Bytes) IsZero() bool {
 
 // Scan implements the Scanner interface.
 func (b *Bytes) Scan(value interface{}) error {
-	b.set = true
 	if value == nil {
-		b.Bytes, b.Valid = []byte{}, false
+		b.Bytes, b.Valid, b.set = nil, false, false
 		return nil
 	}
-	b.Valid = true
+	b.Valid, b.set = true, true
 	return convert.ConvertAssign(&b.Bytes, value)
 }
 

--- a/bytes.go
+++ b/bytes.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/volatiletech/null/v8/convert"
+	"github.com/razor-1/null/v9/convert"
 )
 
 // NullBytes is a global byte slice of JSON null
@@ -67,6 +67,7 @@ func (b *Bytes) UnmarshalJSON(data []byte) error {
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (b *Bytes) UnmarshalText(text []byte) error {
+	b.set = true
 	if len(text) == 0 {
 		b.Bytes = nil
 		b.Valid = false
@@ -98,6 +99,7 @@ func (b Bytes) MarshalText() ([]byte, error) {
 func (b *Bytes) SetValid(n []byte) {
 	b.Bytes = n
 	b.Valid = true
+	b.set = true
 }
 
 // Ptr returns a pointer to this Bytes's value, or a nil pointer if this Bytes is null.
@@ -115,6 +117,7 @@ func (b Bytes) IsZero() bool {
 
 // Scan implements the Scanner interface.
 func (b *Bytes) Scan(value interface{}) error {
+	b.set = true
 	if value == nil {
 		b.Bytes, b.Valid = []byte{}, false
 		return nil

--- a/bytes.go
+++ b/bytes.go
@@ -15,32 +15,40 @@ var NullBytes = []byte("null")
 type Bytes struct {
 	Bytes []byte
 	Valid bool
+	set   bool
 }
 
 // NewBytes creates a new Bytes
-func NewBytes(b []byte, valid bool) Bytes {
+func NewBytes(b []byte, valid, set bool) Bytes {
 	return Bytes{
 		Bytes: b,
 		Valid: valid,
+		set:   set,
 	}
 }
 
 // BytesFrom creates a new Bytes that will be invalid if nil.
 func BytesFrom(b []byte) Bytes {
-	return NewBytes(b, b != nil)
+	return NewBytes(b, b != nil, true)
 }
 
 // BytesFromPtr creates a new Bytes that will be invalid if nil.
 func BytesFromPtr(b *[]byte) Bytes {
 	if b == nil {
-		return NewBytes(nil, false)
+		return NewBytes(nil, false, true)
 	}
-	n := NewBytes(*b, true)
+	n := NewBytes(*b, true, true)
 	return n
+}
+
+func (b Bytes) IsSet() bool {
+	return b.set
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (b *Bytes) UnmarshalJSON(data []byte) error {
+	b.set = true
+
 	if bytes.Equal(data, NullBytes) {
 		b.Valid = false
 		b.Bytes = nil

--- a/bytes_test.go
+++ b/bytes_test.go
@@ -57,8 +57,8 @@ func TestUnmarshalBytes(t *testing.T) {
 	if null.Bytes != nil {
 		t.Errorf("Expected Bytes to be nil, but was not: %#v %#v", null.Bytes, []byte(`null`))
 	}
-	if !null.set {
-		t.Errorf("Expected set to be true; got false")
+	if !null.Set {
+		t.Errorf("Expected Set to be true; got false")
 	}
 }
 

--- a/bytes_test.go
+++ b/bytes_test.go
@@ -81,7 +81,7 @@ func TestMarshalBytes(t *testing.T) {
 	assertJSONEquals(t, data, string(b64BytesJSON), "non-empty json marshal")
 
 	// invalid values should be encoded as null
-	null := NewBytes(nil, false, true)
+	null := NewBytes(nil, false)
 	data, err = json.Marshal(null)
 	maybePanic(err)
 	assertJSONEquals(t, data, "null", "null json marshal")
@@ -94,7 +94,7 @@ func TestMarshalBytesText(t *testing.T) {
 	assertJSONEquals(t, data, `"hello"`, "non-empty text marshal")
 
 	// invalid values should be encoded as null
-	null := NewBytes(nil, false, true)
+	null := NewBytes(nil, false)
 	data, err = null.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "null text marshal")
@@ -107,7 +107,7 @@ func TestBytesPointer(t *testing.T) {
 		t.Errorf("bad %s []byte: %#v ≠ %s\n", "pointer", ptr, `"hello"`)
 	}
 
-	null := NewBytes(nil, false, true)
+	null := NewBytes(nil, false)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s []byte: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -120,19 +120,19 @@ func TestBytesIsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	null := NewBytes(nil, false, true)
+	null := NewBytes(nil, false)
 	if !null.IsZero() {
 		t.Errorf("IsZero() should be true")
 	}
 
-	zero := NewBytes(nil, true, true)
+	zero := NewBytes(nil, true)
 	if zero.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
 }
 
 func TestBytesSetValid(t *testing.T) {
-	change := NewBytes(nil, false, true)
+	change := NewBytes(nil, false)
 	assertNullBytes(t, change, "SetValid()")
 	change.SetValid(hello)
 	assertBytes(t, change, "SetValid()")

--- a/bytes_test.go
+++ b/bytes_test.go
@@ -7,7 +7,8 @@ import (
 )
 
 var (
-	bytesJSON = []byte(`"hello"`)
+	bytesJSON    = []byte(`"hello"`)
+	b64BytesJSON = []byte(`"aGVsbG8="`)
 )
 
 func TestBytesFrom(t *testing.T) {
@@ -37,7 +38,7 @@ func TestBytesFromPtr(t *testing.T) {
 
 func TestUnmarshalBytes(t *testing.T) {
 	var i Bytes
-	err := json.Unmarshal(bytesJSON, &i)
+	err := json.Unmarshal(b64BytesJSON, &i)
 	maybePanic(err)
 	assertBytes(t, i, "[]byte json")
 
@@ -70,10 +71,10 @@ func TestTextUnmarshalBytes(t *testing.T) {
 }
 
 func TestMarshalBytes(t *testing.T) {
-	i := BytesFrom([]byte(`"hello"`))
+	i := BytesFrom([]byte(`hello`))
 	data, err := json.Marshal(i)
 	maybePanic(err)
-	assertJSONEquals(t, data, `"hello"`, "non-empty json marshal")
+	assertJSONEquals(t, data, string(b64BytesJSON), "non-empty json marshal")
 
 	// invalid values should be encoded as null
 	null := NewBytes(nil, false)

--- a/float32.go
+++ b/float32.go
@@ -17,25 +17,25 @@ type Float32 struct {
 }
 
 // NewFloat32 creates a new Float32
-func NewFloat32(f float32, valid, set bool) Float32 {
+func NewFloat32(f float32, valid bool) Float32 {
 	return Float32{
 		Float32: f,
 		Valid:   valid,
-		Set:     set,
+		Set:     true,
 	}
 }
 
 // Float32From creates a new Float32 that will always be valid.
 func Float32From(f float32) Float32 {
-	return NewFloat32(f, true, true)
+	return NewFloat32(f, true)
 }
 
 // Float32FromPtr creates a new Float32 that be null if f is nil.
 func Float32FromPtr(f *float32) Float32 {
 	if f == nil {
-		return NewFloat32(0, false, true)
+		return NewFloat32(0, false)
 	}
-	return NewFloat32(*f, true, true)
+	return NewFloat32(*f, true)
 }
 
 func (f Float32) IsSet() bool {

--- a/float32.go
+++ b/float32.go
@@ -115,12 +115,11 @@ func (f Float32) IsZero() bool {
 
 // Scan implements the Scanner interface.
 func (f *Float32) Scan(value interface{}) error {
-	f.set = true
 	if value == nil {
-		f.Float32, f.Valid = 0, false
+		f.Float32, f.Valid, f.set = 0, false, false
 		return nil
 	}
-	f.Valid = true
+	f.Valid, f.set = true, true
 	return convert.ConvertAssign(&f.Float32, value)
 }
 

--- a/float32.go
+++ b/float32.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"strconv"
 
-	"github.com/volatiletech/null/v8/convert"
+	"github.com/razor-1/null/v9/convert"
 )
 
 // Float32 is a nullable float32.
@@ -63,6 +63,7 @@ func (f *Float32) UnmarshalJSON(data []byte) error {
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (f *Float32) UnmarshalText(text []byte) error {
+	f.set = true
 	if text == nil || len(text) == 0 {
 		f.Valid = false
 		return nil
@@ -96,6 +97,7 @@ func (f Float32) MarshalText() ([]byte, error) {
 func (f *Float32) SetValid(n float32) {
 	f.Float32 = n
 	f.Valid = true
+	f.set = true
 }
 
 // Ptr returns a pointer to this Float32's value, or a nil pointer if this Float32 is null.
@@ -113,6 +115,7 @@ func (f Float32) IsZero() bool {
 
 // Scan implements the Scanner interface.
 func (f *Float32) Scan(value interface{}) error {
+	f.set = true
 	if value == nil {
 		f.Float32, f.Valid = 0, false
 		return nil

--- a/float32.go
+++ b/float32.go
@@ -13,7 +13,7 @@ import (
 type Float32 struct {
 	Float32 float32
 	Valid   bool
-	set     bool
+	Set     bool
 }
 
 // NewFloat32 creates a new Float32
@@ -21,7 +21,7 @@ func NewFloat32(f float32, valid, set bool) Float32 {
 	return Float32{
 		Float32: f,
 		Valid:   valid,
-		set:     set,
+		Set:     set,
 	}
 }
 
@@ -39,12 +39,12 @@ func Float32FromPtr(f *float32) Float32 {
 }
 
 func (f Float32) IsSet() bool {
-	return f.set
+	return f.Set
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (f *Float32) UnmarshalJSON(data []byte) error {
-	f.set = true
+	f.Set = true
 	if bytes.Equal(data, NullBytes) {
 		f.Valid = false
 		f.Float32 = 0
@@ -63,7 +63,7 @@ func (f *Float32) UnmarshalJSON(data []byte) error {
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (f *Float32) UnmarshalText(text []byte) error {
-	f.set = true
+	f.Set = true
 	if text == nil || len(text) == 0 {
 		f.Valid = false
 		return nil
@@ -97,7 +97,7 @@ func (f Float32) MarshalText() ([]byte, error) {
 func (f *Float32) SetValid(n float32) {
 	f.Float32 = n
 	f.Valid = true
-	f.set = true
+	f.Set = true
 }
 
 // Ptr returns a pointer to this Float32's value, or a nil pointer if this Float32 is null.
@@ -116,10 +116,10 @@ func (f Float32) IsZero() bool {
 // Scan implements the Scanner interface.
 func (f *Float32) Scan(value interface{}) error {
 	if value == nil {
-		f.Float32, f.Valid, f.set = 0, false, false
+		f.Float32, f.Valid, f.Set = 0, false, false
 		return nil
 	}
-	f.Valid, f.set = true, true
+	f.Valid, f.Set = true, true
 	return convert.ConvertAssign(&f.Float32, value)
 }
 

--- a/float32.go
+++ b/float32.go
@@ -13,31 +13,38 @@ import (
 type Float32 struct {
 	Float32 float32
 	Valid   bool
+	set     bool
 }
 
 // NewFloat32 creates a new Float32
-func NewFloat32(f float32, valid bool) Float32 {
+func NewFloat32(f float32, valid, set bool) Float32 {
 	return Float32{
 		Float32: f,
 		Valid:   valid,
+		set:     set,
 	}
 }
 
 // Float32From creates a new Float32 that will always be valid.
 func Float32From(f float32) Float32 {
-	return NewFloat32(f, true)
+	return NewFloat32(f, true, true)
 }
 
 // Float32FromPtr creates a new Float32 that be null if f is nil.
 func Float32FromPtr(f *float32) Float32 {
 	if f == nil {
-		return NewFloat32(0, false)
+		return NewFloat32(0, false, true)
 	}
-	return NewFloat32(*f, true)
+	return NewFloat32(*f, true, true)
+}
+
+func (f Float32) IsSet() bool {
+	return f.set
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (f *Float32) UnmarshalJSON(data []byte) error {
+	f.set = true
 	if bytes.Equal(data, NullBytes) {
 		f.Valid = false
 		f.Float32 = 0

--- a/float32_test.go
+++ b/float32_test.go
@@ -39,6 +39,9 @@ func TestUnmarshalFloat32(t *testing.T) {
 	err = json.Unmarshal(nullJSON, &null)
 	maybePanic(err)
 	assertNullFloat32(t, null, "null json")
+	if !null.set {
+		t.Error("should be set")
+	}
 
 	var badType Float32
 	err = json.Unmarshal(boolJSON, &badType)
@@ -73,7 +76,7 @@ func TestMarshalFloat32(t *testing.T) {
 	assertJSONEquals(t, data, "1.2345", "non-empty json marshal")
 
 	// invalid values should be encoded as null
-	null := NewFloat32(0, false)
+	null := NewFloat32(0, false, true)
 	data, err = json.Marshal(null)
 	maybePanic(err)
 	assertJSONEquals(t, data, "null", "null json marshal")
@@ -86,7 +89,7 @@ func TestMarshalFloat32Text(t *testing.T) {
 	assertJSONEquals(t, data, "1.2345", "non-empty text marshal")
 
 	// invalid values should be encoded as null
-	null := NewFloat32(0, false)
+	null := NewFloat32(0, false, true)
 	data, err = null.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "null text marshal")
@@ -99,7 +102,7 @@ func TestFloat32Pointer(t *testing.T) {
 		t.Errorf("bad %s float32: %#v ≠ %v\n", "pointer", ptr, 1.2345)
 	}
 
-	null := NewFloat32(0, false)
+	null := NewFloat32(0, false, true)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s float32: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -112,19 +115,19 @@ func TestFloat32IsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	null := NewFloat32(0, false)
+	null := NewFloat32(0, false, true)
 	if !null.IsZero() {
 		t.Errorf("IsZero() should be true")
 	}
 
-	zero := NewFloat32(0, true)
+	zero := NewFloat32(0, true, true)
 	if zero.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
 }
 
 func TestFloat32SetValid(t *testing.T) {
-	change := NewFloat32(0, false)
+	change := NewFloat32(0, false, true)
 	assertNullFloat32(t, change, "SetValid()")
 	change.SetValid(1.2345)
 	assertFloat32(t, change, "SetValid()")

--- a/float32_test.go
+++ b/float32_test.go
@@ -39,8 +39,8 @@ func TestUnmarshalFloat32(t *testing.T) {
 	err = json.Unmarshal(nullJSON, &null)
 	maybePanic(err)
 	assertNullFloat32(t, null, "null json")
-	if !null.set {
-		t.Error("should be set")
+	if !null.Set {
+		t.Error("should be Set")
 	}
 
 	var badType Float32

--- a/float32_test.go
+++ b/float32_test.go
@@ -76,7 +76,7 @@ func TestMarshalFloat32(t *testing.T) {
 	assertJSONEquals(t, data, "1.2345", "non-empty json marshal")
 
 	// invalid values should be encoded as null
-	null := NewFloat32(0, false, true)
+	null := NewFloat32(0, false)
 	data, err = json.Marshal(null)
 	maybePanic(err)
 	assertJSONEquals(t, data, "null", "null json marshal")
@@ -89,7 +89,7 @@ func TestMarshalFloat32Text(t *testing.T) {
 	assertJSONEquals(t, data, "1.2345", "non-empty text marshal")
 
 	// invalid values should be encoded as null
-	null := NewFloat32(0, false, true)
+	null := NewFloat32(0, false)
 	data, err = null.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "null text marshal")
@@ -102,7 +102,7 @@ func TestFloat32Pointer(t *testing.T) {
 		t.Errorf("bad %s float32: %#v ≠ %v\n", "pointer", ptr, 1.2345)
 	}
 
-	null := NewFloat32(0, false, true)
+	null := NewFloat32(0, false)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s float32: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -115,19 +115,19 @@ func TestFloat32IsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	null := NewFloat32(0, false, true)
+	null := NewFloat32(0, false)
 	if !null.IsZero() {
 		t.Errorf("IsZero() should be true")
 	}
 
-	zero := NewFloat32(0, true, true)
+	zero := NewFloat32(0, true)
 	if zero.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
 }
 
 func TestFloat32SetValid(t *testing.T) {
-	change := NewFloat32(0, false, true)
+	change := NewFloat32(0, false)
 	assertNullFloat32(t, change, "SetValid()")
 	change.SetValid(1.2345)
 	assertFloat32(t, change, "SetValid()")

--- a/float64.go
+++ b/float64.go
@@ -17,25 +17,25 @@ type Float64 struct {
 }
 
 // NewFloat64 creates a new Float64
-func NewFloat64(f float64, valid, set bool) Float64 {
+func NewFloat64(f float64, valid bool) Float64 {
 	return Float64{
 		Float64: f,
 		Valid:   valid,
-		Set:     set,
+		Set:     true,
 	}
 }
 
 // Float64From creates a new Float64 that will always be valid.
 func Float64From(f float64) Float64 {
-	return NewFloat64(f, true, true)
+	return NewFloat64(f, true)
 }
 
 // Float64FromPtr creates a new Float64 that be null if f is nil.
 func Float64FromPtr(f *float64) Float64 {
 	if f == nil {
-		return NewFloat64(0, false, true)
+		return NewFloat64(0, false)
 	}
-	return NewFloat64(*f, true, true)
+	return NewFloat64(*f, true)
 }
 
 func (f Float64) IsSet() bool {

--- a/float64.go
+++ b/float64.go
@@ -13,31 +13,38 @@ import (
 type Float64 struct {
 	Float64 float64
 	Valid   bool
+	set     bool
 }
 
 // NewFloat64 creates a new Float64
-func NewFloat64(f float64, valid bool) Float64 {
+func NewFloat64(f float64, valid, set bool) Float64 {
 	return Float64{
 		Float64: f,
 		Valid:   valid,
+		set:     set,
 	}
 }
 
 // Float64From creates a new Float64 that will always be valid.
 func Float64From(f float64) Float64 {
-	return NewFloat64(f, true)
+	return NewFloat64(f, true, true)
 }
 
 // Float64FromPtr creates a new Float64 that be null if f is nil.
 func Float64FromPtr(f *float64) Float64 {
 	if f == nil {
-		return NewFloat64(0, false)
+		return NewFloat64(0, false, true)
 	}
-	return NewFloat64(*f, true)
+	return NewFloat64(*f, true, true)
+}
+
+func (f Float64) IsSet() bool {
+	return f.set
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (f *Float64) UnmarshalJSON(data []byte) error {
+	f.set = true
 	if bytes.Equal(data, NullBytes) {
 		f.Float64 = 0
 		f.Valid = false

--- a/float64.go
+++ b/float64.go
@@ -110,12 +110,11 @@ func (f Float64) IsZero() bool {
 
 // Scan implements the Scanner interface.
 func (f *Float64) Scan(value interface{}) error {
-	f.set = true
 	if value == nil {
-		f.Float64, f.Valid = 0, false
+		f.Float64, f.Valid, f.set = 0, false, false
 		return nil
 	}
-	f.Valid = true
+	f.Valid, f.set = true, true
 	return convert.ConvertAssign(&f.Float64, value)
 }
 

--- a/float64.go
+++ b/float64.go
@@ -13,7 +13,7 @@ import (
 type Float64 struct {
 	Float64 float64
 	Valid   bool
-	set     bool
+	Set     bool
 }
 
 // NewFloat64 creates a new Float64
@@ -21,7 +21,7 @@ func NewFloat64(f float64, valid, set bool) Float64 {
 	return Float64{
 		Float64: f,
 		Valid:   valid,
-		set:     set,
+		Set:     set,
 	}
 }
 
@@ -39,12 +39,12 @@ func Float64FromPtr(f *float64) Float64 {
 }
 
 func (f Float64) IsSet() bool {
-	return f.set
+	return f.Set
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (f *Float64) UnmarshalJSON(data []byte) error {
-	f.set = true
+	f.Set = true
 	if bytes.Equal(data, NullBytes) {
 		f.Float64 = 0
 		f.Valid = false
@@ -61,7 +61,7 @@ func (f *Float64) UnmarshalJSON(data []byte) error {
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (f *Float64) UnmarshalText(text []byte) error {
-	f.set = true
+	f.Set = true
 	if text == nil || len(text) == 0 {
 		f.Valid = false
 		return nil
@@ -92,7 +92,7 @@ func (f Float64) MarshalText() ([]byte, error) {
 func (f *Float64) SetValid(n float64) {
 	f.Float64 = n
 	f.Valid = true
-	f.set = true
+	f.Set = true
 }
 
 // Ptr returns a pointer to this Float64's value, or a nil pointer if this Float64 is null.
@@ -111,10 +111,10 @@ func (f Float64) IsZero() bool {
 // Scan implements the Scanner interface.
 func (f *Float64) Scan(value interface{}) error {
 	if value == nil {
-		f.Float64, f.Valid, f.set = 0, false, false
+		f.Float64, f.Valid, f.Set = 0, false, false
 		return nil
 	}
-	f.Valid, f.set = true, true
+	f.Valid, f.Set = true, true
 	return convert.ConvertAssign(&f.Float64, value)
 }
 

--- a/float64.go
+++ b/float64.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"strconv"
 
-	"github.com/volatiletech/null/v8/convert"
+	"github.com/razor-1/null/v9/convert"
 )
 
 // Float64 is a nullable float64.
@@ -61,6 +61,7 @@ func (f *Float64) UnmarshalJSON(data []byte) error {
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (f *Float64) UnmarshalText(text []byte) error {
+	f.set = true
 	if text == nil || len(text) == 0 {
 		f.Valid = false
 		return nil
@@ -91,6 +92,7 @@ func (f Float64) MarshalText() ([]byte, error) {
 func (f *Float64) SetValid(n float64) {
 	f.Float64 = n
 	f.Valid = true
+	f.set = true
 }
 
 // Ptr returns a pointer to this Float64's value, or a nil pointer if this Float64 is null.
@@ -108,6 +110,7 @@ func (f Float64) IsZero() bool {
 
 // Scan implements the Scanner interface.
 func (f *Float64) Scan(value interface{}) error {
+	f.set = true
 	if value == nil {
 		f.Float64, f.Valid = 0, false
 		return nil

--- a/float64_test.go
+++ b/float64_test.go
@@ -76,7 +76,7 @@ func TestMarshalFloat64(t *testing.T) {
 	assertJSONEquals(t, data, "1.2345", "non-empty json marshal")
 
 	// invalid values should be encoded as null
-	null := NewFloat64(0, false, true)
+	null := NewFloat64(0, false)
 	data, err = json.Marshal(null)
 	maybePanic(err)
 	assertJSONEquals(t, data, "null", "null json marshal")
@@ -89,7 +89,7 @@ func TestMarshalFloat64Text(t *testing.T) {
 	assertJSONEquals(t, data, "1.2345", "non-empty text marshal")
 
 	// invalid values should be encoded as null
-	null := NewFloat64(0, false, true)
+	null := NewFloat64(0, false)
 	data, err = null.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "null text marshal")
@@ -102,7 +102,7 @@ func TestFloat64Pointer(t *testing.T) {
 		t.Errorf("bad %s float64: %#v ≠ %v\n", "pointer", ptr, 1.2345)
 	}
 
-	null := NewFloat64(0, false, true)
+	null := NewFloat64(0, false)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s float64: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -115,19 +115,19 @@ func TestFloat64IsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	null := NewFloat64(0, false, true)
+	null := NewFloat64(0, false)
 	if !null.IsZero() {
 		t.Errorf("IsZero() should be true")
 	}
 
-	zero := NewFloat64(0, true, true)
+	zero := NewFloat64(0, true)
 	if zero.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
 }
 
 func TestFloat64SetValid(t *testing.T) {
-	change := NewFloat64(0, false, true)
+	change := NewFloat64(0, false)
 	assertNullFloat64(t, change, "SetValid()")
 	change.SetValid(1.2345)
 	assertFloat64(t, change, "SetValid()")

--- a/float64_test.go
+++ b/float64_test.go
@@ -39,6 +39,9 @@ func TestUnmarshalFloat64(t *testing.T) {
 	err = json.Unmarshal(nullJSON, &null)
 	maybePanic(err)
 	assertNullFloat64(t, null, "null json")
+	if !null.set {
+		t.Error("should be set")
+	}
 
 	var badType Float64
 	err = json.Unmarshal(boolJSON, &badType)
@@ -73,7 +76,7 @@ func TestMarshalFloat64(t *testing.T) {
 	assertJSONEquals(t, data, "1.2345", "non-empty json marshal")
 
 	// invalid values should be encoded as null
-	null := NewFloat64(0, false)
+	null := NewFloat64(0, false, true)
 	data, err = json.Marshal(null)
 	maybePanic(err)
 	assertJSONEquals(t, data, "null", "null json marshal")
@@ -86,7 +89,7 @@ func TestMarshalFloat64Text(t *testing.T) {
 	assertJSONEquals(t, data, "1.2345", "non-empty text marshal")
 
 	// invalid values should be encoded as null
-	null := NewFloat64(0, false)
+	null := NewFloat64(0, false, true)
 	data, err = null.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "null text marshal")
@@ -99,7 +102,7 @@ func TestFloat64Pointer(t *testing.T) {
 		t.Errorf("bad %s float64: %#v ≠ %v\n", "pointer", ptr, 1.2345)
 	}
 
-	null := NewFloat64(0, false)
+	null := NewFloat64(0, false, true)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s float64: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -112,19 +115,19 @@ func TestFloat64IsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	null := NewFloat64(0, false)
+	null := NewFloat64(0, false, true)
 	if !null.IsZero() {
 		t.Errorf("IsZero() should be true")
 	}
 
-	zero := NewFloat64(0, true)
+	zero := NewFloat64(0, true, true)
 	if zero.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
 }
 
 func TestFloat64SetValid(t *testing.T) {
-	change := NewFloat64(0, false)
+	change := NewFloat64(0, false, true)
 	assertNullFloat64(t, change, "SetValid()")
 	change.SetValid(1.2345)
 	assertFloat64(t, change, "SetValid()")

--- a/float64_test.go
+++ b/float64_test.go
@@ -39,8 +39,8 @@ func TestUnmarshalFloat64(t *testing.T) {
 	err = json.Unmarshal(nullJSON, &null)
 	maybePanic(err)
 	assertNullFloat64(t, null, "null json")
-	if !null.set {
-		t.Error("should be set")
+	if !null.Set {
+		t.Error("should be Set")
 	}
 
 	var badType Float64

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/volatiletech/null/v8
+module github.com/razor-1/null/v9
 
 go 1.14
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,6 @@ module github.com/razor-1/null/v9
 
 go 1.14
 
-require github.com/volatiletech/randomize v0.0.1
+require (
+	github.com/volatiletech/randomize v0.0.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
+github.com/friendsofgo/errors v0.9.2 h1:X6NYxef4efCBdwI7BgS820zFaN7Cphrmb+Pljdzjtgk=
 github.com/friendsofgo/errors v0.9.2/go.mod h1:yCvFW5AkDIL9qn7suHVLiI/gH228n7PC4Pn44IGoTOI=
+github.com/gofrs/uuid v3.2.0+incompatible h1:y12jRkkFxsd7GpqdSZ+/KCs/fJbqpEXSGd4+jfEaewE=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/volatiletech/inflect v0.0.1 h1:2a6FcMQyhmPZcLa+uet3VJ8gLn/9svWhJxJYwvE8KsU=
 github.com/volatiletech/inflect v0.0.1/go.mod h1:IBti31tG6phkHitLlr5j7shC5SOo//x0AjDzaJU1PLA=

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/gofrs/uuid v3.2.0+incompatible h1:y12jRkkFxsd7GpqdSZ+/KCs/fJbqpEXSGd4
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/volatiletech/inflect v0.0.1 h1:2a6FcMQyhmPZcLa+uet3VJ8gLn/9svWhJxJYwvE8KsU=
 github.com/volatiletech/inflect v0.0.1/go.mod h1:IBti31tG6phkHitLlr5j7shC5SOo//x0AjDzaJU1PLA=
+github.com/volatiletech/null/v8 v8.1.0 h1:eAO3I31A5R04usY5SKMMfDcOCnEGyT/T4wRI0JVGp4U=
+github.com/volatiletech/null/v8 v8.1.0/go.mod h1:98DbwNoKEpRrYtGjWFctievIfm4n4MxG0A6EBUcoS5g=
 github.com/volatiletech/randomize v0.0.1 h1:eE5yajattWqTB2/eN8df4dw+8jwAzBtbdo5sbWC4nMk=
 github.com/volatiletech/randomize v0.0.1/go.mod h1:GN3U0QYqfZ9FOJ67bzax1cqZ5q2xuj2mXrXBjWaRTlY=
 github.com/volatiletech/strmangle v0.0.1 h1:UKQoHmY6be/R3tSvD2nQYrH41k43OJkidwEiC74KIzk=

--- a/int.go
+++ b/int.go
@@ -14,31 +14,39 @@ import (
 type Int struct {
 	Int   int
 	Valid bool
+	set   bool
 }
 
 // NewInt creates a new Int
-func NewInt(i int, valid bool) Int {
+func NewInt(i int, valid, set bool) Int {
 	return Int{
 		Int:   i,
 		Valid: valid,
+		set:   set,
 	}
 }
 
 // IntFrom creates a new Int that will always be valid.
 func IntFrom(i int) Int {
-	return NewInt(i, true)
+	return NewInt(i, true, true)
 }
 
 // IntFromPtr creates a new Int that be null if i is nil.
 func IntFromPtr(i *int) Int {
 	if i == nil {
-		return NewInt(0, false)
+		return NewInt(0, false, true)
 	}
-	return NewInt(*i, true)
+	return NewInt(*i, true, true)
+}
+
+func (i Int) IsSet() bool {
+	return i.set
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (i *Int) UnmarshalJSON(data []byte) error {
+	i.set = true
+
 	if bytes.Equal(data, NullBytes) {
 		i.Valid = false
 		i.Int = 0

--- a/int.go
+++ b/int.go
@@ -7,7 +7,7 @@ import (
 	"math"
 	"strconv"
 
-	"github.com/volatiletech/null/v8/convert"
+	"github.com/razor-1/null/v9/convert"
 )
 
 // Int is an nullable int.
@@ -65,6 +65,7 @@ func (i *Int) UnmarshalJSON(data []byte) error {
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (i *Int) UnmarshalText(text []byte) error {
+	i.set = true
 	if text == nil || len(text) == 0 {
 		i.Valid = false
 		return nil
@@ -98,6 +99,7 @@ func (i Int) MarshalText() ([]byte, error) {
 func (i *Int) SetValid(n int) {
 	i.Int = n
 	i.Valid = true
+	i.set = true
 }
 
 // Ptr returns a pointer to this Int's value, or a nil pointer if this Int is null.
@@ -115,6 +117,7 @@ func (i Int) IsZero() bool {
 
 // Scan implements the Scanner interface.
 func (i *Int) Scan(value interface{}) error {
+	i.set = true
 	if value == nil {
 		i.Int, i.Valid = 0, false
 		return nil

--- a/int.go
+++ b/int.go
@@ -117,12 +117,11 @@ func (i Int) IsZero() bool {
 
 // Scan implements the Scanner interface.
 func (i *Int) Scan(value interface{}) error {
-	i.set = true
 	if value == nil {
-		i.Int, i.Valid = 0, false
+		i.Int, i.Valid, i.set = 0, false, false
 		return nil
 	}
-	i.Valid = true
+	i.Valid, i.set = true, true
 	return convert.ConvertAssign(&i.Int, value)
 }
 

--- a/int.go
+++ b/int.go
@@ -14,7 +14,7 @@ import (
 type Int struct {
 	Int   int
 	Valid bool
-	set   bool
+	Set   bool
 }
 
 // NewInt creates a new Int
@@ -22,7 +22,7 @@ func NewInt(i int, valid, set bool) Int {
 	return Int{
 		Int:   i,
 		Valid: valid,
-		set:   set,
+		Set:   set,
 	}
 }
 
@@ -40,12 +40,12 @@ func IntFromPtr(i *int) Int {
 }
 
 func (i Int) IsSet() bool {
-	return i.set
+	return i.Set
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (i *Int) UnmarshalJSON(data []byte) error {
-	i.set = true
+	i.Set = true
 
 	if bytes.Equal(data, NullBytes) {
 		i.Valid = false
@@ -65,7 +65,7 @@ func (i *Int) UnmarshalJSON(data []byte) error {
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (i *Int) UnmarshalText(text []byte) error {
-	i.set = true
+	i.Set = true
 	if text == nil || len(text) == 0 {
 		i.Valid = false
 		return nil
@@ -99,7 +99,7 @@ func (i Int) MarshalText() ([]byte, error) {
 func (i *Int) SetValid(n int) {
 	i.Int = n
 	i.Valid = true
-	i.set = true
+	i.Set = true
 }
 
 // Ptr returns a pointer to this Int's value, or a nil pointer if this Int is null.
@@ -118,10 +118,10 @@ func (i Int) IsZero() bool {
 // Scan implements the Scanner interface.
 func (i *Int) Scan(value interface{}) error {
 	if value == nil {
-		i.Int, i.Valid, i.set = 0, false, false
+		i.Int, i.Valid, i.Set = 0, false, false
 		return nil
 	}
-	i.Valid, i.set = true, true
+	i.Valid, i.Set = true, true
 	return convert.ConvertAssign(&i.Int, value)
 }
 

--- a/int.go
+++ b/int.go
@@ -18,25 +18,25 @@ type Int struct {
 }
 
 // NewInt creates a new Int
-func NewInt(i int, valid, set bool) Int {
+func NewInt(i int, valid bool) Int {
 	return Int{
 		Int:   i,
 		Valid: valid,
-		Set:   set,
+		Set:   true,
 	}
 }
 
 // IntFrom creates a new Int that will always be valid.
 func IntFrom(i int) Int {
-	return NewInt(i, true, true)
+	return NewInt(i, true)
 }
 
 // IntFromPtr creates a new Int that be null if i is nil.
 func IntFromPtr(i *int) Int {
 	if i == nil {
-		return NewInt(0, false, true)
+		return NewInt(0, false)
 	}
-	return NewInt(*i, true, true)
+	return NewInt(*i, true)
 }
 
 func (i Int) IsSet() bool {

--- a/int16.go
+++ b/int16.go
@@ -8,7 +8,7 @@ import (
 	"math"
 	"strconv"
 
-	"github.com/volatiletech/null/v8/convert"
+	"github.com/razor-1/null/v9/convert"
 )
 
 // Int16 is an nullable int16.
@@ -69,6 +69,7 @@ func (i *Int16) UnmarshalJSON(data []byte) error {
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (i *Int16) UnmarshalText(text []byte) error {
+	i.set = true
 	if text == nil || len(text) == 0 {
 		i.Valid = false
 		return nil
@@ -102,6 +103,7 @@ func (i Int16) MarshalText() ([]byte, error) {
 func (i *Int16) SetValid(n int16) {
 	i.Int16 = n
 	i.Valid = true
+	i.set = true
 }
 
 // Ptr returns a pointer to this Int16's value, or a nil pointer if this Int16 is null.
@@ -119,6 +121,7 @@ func (i Int16) IsZero() bool {
 
 // Scan implements the Scanner interface.
 func (i *Int16) Scan(value interface{}) error {
+	i.set = true
 	if value == nil {
 		i.Int16, i.Valid = 0, false
 		return nil

--- a/int16.go
+++ b/int16.go
@@ -19,25 +19,25 @@ type Int16 struct {
 }
 
 // NewInt16 creates a new Int16
-func NewInt16(i int16, valid, set bool) Int16 {
+func NewInt16(i int16, valid bool) Int16 {
 	return Int16{
 		Int16: i,
 		Valid: valid,
-		Set:   set,
+		Set:   true,
 	}
 }
 
 // Int16From creates a new Int16 that will always be valid.
 func Int16From(i int16) Int16 {
-	return NewInt16(i, true, true)
+	return NewInt16(i, true)
 }
 
 // Int16FromPtr creates a new Int16 that be null if i is nil.
 func Int16FromPtr(i *int16) Int16 {
 	if i == nil {
-		return NewInt16(0, false, true)
+		return NewInt16(0, false)
 	}
-	return NewInt16(*i, true, true)
+	return NewInt16(*i, true)
 }
 
 func (i Int16) IsSet() bool {

--- a/int16.go
+++ b/int16.go
@@ -48,8 +48,7 @@ func (i Int16) IsSet() bool {
 func (i *Int16) UnmarshalJSON(data []byte) error {
 	i.set = true
 	if bytes.Equal(data, NullBytes) {
-		i.Valid = false
-		i.Int16 = 0
+		i.Int16, i.Valid = 0, false
 		return nil
 	}
 
@@ -62,8 +61,7 @@ func (i *Int16) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("json: %d overflows max int16 value", x)
 	}
 
-	i.Int16 = int16(x)
-	i.Valid = true
+	i.Int16, i.Valid = int16(x), true
 	return nil
 }
 
@@ -121,12 +119,11 @@ func (i Int16) IsZero() bool {
 
 // Scan implements the Scanner interface.
 func (i *Int16) Scan(value interface{}) error {
-	i.set = true
 	if value == nil {
-		i.Int16, i.Valid = 0, false
+		i.Int16, i.Valid, i.set = 0, false, false
 		return nil
 	}
-	i.Valid = true
+	i.Valid, i.set = true, true
 	return convert.ConvertAssign(&i.Int16, value)
 }
 

--- a/int16.go
+++ b/int16.go
@@ -15,7 +15,7 @@ import (
 type Int16 struct {
 	Int16 int16
 	Valid bool
-	set   bool
+	Set   bool
 }
 
 // NewInt16 creates a new Int16
@@ -23,7 +23,7 @@ func NewInt16(i int16, valid, set bool) Int16 {
 	return Int16{
 		Int16: i,
 		Valid: valid,
-		set:   set,
+		Set:   set,
 	}
 }
 
@@ -41,12 +41,12 @@ func Int16FromPtr(i *int16) Int16 {
 }
 
 func (i Int16) IsSet() bool {
-	return i.set
+	return i.Set
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (i *Int16) UnmarshalJSON(data []byte) error {
-	i.set = true
+	i.Set = true
 	if bytes.Equal(data, NullBytes) {
 		i.Int16, i.Valid = 0, false
 		return nil
@@ -67,7 +67,7 @@ func (i *Int16) UnmarshalJSON(data []byte) error {
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (i *Int16) UnmarshalText(text []byte) error {
-	i.set = true
+	i.Set = true
 	if text == nil || len(text) == 0 {
 		i.Valid = false
 		return nil
@@ -101,7 +101,7 @@ func (i Int16) MarshalText() ([]byte, error) {
 func (i *Int16) SetValid(n int16) {
 	i.Int16 = n
 	i.Valid = true
-	i.set = true
+	i.Set = true
 }
 
 // Ptr returns a pointer to this Int16's value, or a nil pointer if this Int16 is null.
@@ -120,10 +120,10 @@ func (i Int16) IsZero() bool {
 // Scan implements the Scanner interface.
 func (i *Int16) Scan(value interface{}) error {
 	if value == nil {
-		i.Int16, i.Valid, i.set = 0, false, false
+		i.Int16, i.Valid, i.Set = 0, false, false
 		return nil
 	}
-	i.Valid, i.set = true, true
+	i.Valid, i.Set = true, true
 	return convert.ConvertAssign(&i.Int16, value)
 }
 

--- a/int16.go
+++ b/int16.go
@@ -15,31 +15,38 @@ import (
 type Int16 struct {
 	Int16 int16
 	Valid bool
+	set   bool
 }
 
 // NewInt16 creates a new Int16
-func NewInt16(i int16, valid bool) Int16 {
+func NewInt16(i int16, valid, set bool) Int16 {
 	return Int16{
 		Int16: i,
 		Valid: valid,
+		set:   set,
 	}
 }
 
 // Int16From creates a new Int16 that will always be valid.
 func Int16From(i int16) Int16 {
-	return NewInt16(i, true)
+	return NewInt16(i, true, true)
 }
 
 // Int16FromPtr creates a new Int16 that be null if i is nil.
 func Int16FromPtr(i *int16) Int16 {
 	if i == nil {
-		return NewInt16(0, false)
+		return NewInt16(0, false, true)
 	}
-	return NewInt16(*i, true)
+	return NewInt16(*i, true, true)
+}
+
+func (i Int16) IsSet() bool {
+	return i.set
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (i *Int16) UnmarshalJSON(data []byte) error {
+	i.set = true
 	if bytes.Equal(data, NullBytes) {
 		i.Valid = false
 		i.Int16 = 0

--- a/int16_test.go
+++ b/int16_test.go
@@ -41,8 +41,8 @@ func TestUnmarshalInt16(t *testing.T) {
 	err = json.Unmarshal(nullJSON, &null)
 	maybePanic(err)
 	assertNullInt16(t, null, "null json")
-	if !null.set {
-		t.Error("should be set")
+	if !null.Set {
+		t.Error("should be Set")
 	}
 
 	var badType Int16

--- a/int16_test.go
+++ b/int16_test.go
@@ -102,7 +102,7 @@ func TestMarshalInt16(t *testing.T) {
 	assertJSONEquals(t, data, "32766", "non-empty json marshal")
 
 	// invalid values should be encoded as null
-	null := NewInt16(0, false, true)
+	null := NewInt16(0, false)
 	data, err = json.Marshal(null)
 	maybePanic(err)
 	assertJSONEquals(t, data, "null", "null json marshal")
@@ -115,7 +115,7 @@ func TestMarshalInt16Text(t *testing.T) {
 	assertJSONEquals(t, data, "32766", "non-empty text marshal")
 
 	// invalid values should be encoded as null
-	null := NewInt16(0, false, true)
+	null := NewInt16(0, false)
 	data, err = null.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "null text marshal")
@@ -128,7 +128,7 @@ func TestInt16Pointer(t *testing.T) {
 		t.Errorf("bad %s int16: %#v ≠ %d\n", "pointer", ptr, 32766)
 	}
 
-	null := NewInt16(0, false, true)
+	null := NewInt16(0, false)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s int16: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -141,19 +141,19 @@ func TestInt16IsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	null := NewInt16(0, false, true)
+	null := NewInt16(0, false)
 	if !null.IsZero() {
 		t.Errorf("IsZero() should be true")
 	}
 
-	zero := NewInt16(0, true, true)
+	zero := NewInt16(0, true)
 	if zero.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
 }
 
 func TestInt16SetValid(t *testing.T) {
-	change := NewInt16(0, false, true)
+	change := NewInt16(0, false)
 	assertNullInt16(t, change, "SetValid()")
 	change.SetValid(32766)
 	assertInt16(t, change, "SetValid()")

--- a/int16_test.go
+++ b/int16_test.go
@@ -41,6 +41,9 @@ func TestUnmarshalInt16(t *testing.T) {
 	err = json.Unmarshal(nullJSON, &null)
 	maybePanic(err)
 	assertNullInt16(t, null, "null json")
+	if !null.set {
+		t.Error("should be set")
+	}
 
 	var badType Int16
 	err = json.Unmarshal(boolJSON, &badType)
@@ -99,7 +102,7 @@ func TestMarshalInt16(t *testing.T) {
 	assertJSONEquals(t, data, "32766", "non-empty json marshal")
 
 	// invalid values should be encoded as null
-	null := NewInt16(0, false)
+	null := NewInt16(0, false, true)
 	data, err = json.Marshal(null)
 	maybePanic(err)
 	assertJSONEquals(t, data, "null", "null json marshal")
@@ -112,7 +115,7 @@ func TestMarshalInt16Text(t *testing.T) {
 	assertJSONEquals(t, data, "32766", "non-empty text marshal")
 
 	// invalid values should be encoded as null
-	null := NewInt16(0, false)
+	null := NewInt16(0, false, true)
 	data, err = null.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "null text marshal")
@@ -125,7 +128,7 @@ func TestInt16Pointer(t *testing.T) {
 		t.Errorf("bad %s int16: %#v ≠ %d\n", "pointer", ptr, 32766)
 	}
 
-	null := NewInt16(0, false)
+	null := NewInt16(0, false, true)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s int16: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -138,19 +141,19 @@ func TestInt16IsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	null := NewInt16(0, false)
+	null := NewInt16(0, false, true)
 	if !null.IsZero() {
 		t.Errorf("IsZero() should be true")
 	}
 
-	zero := NewInt16(0, true)
+	zero := NewInt16(0, true, true)
 	if zero.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
 }
 
 func TestInt16SetValid(t *testing.T) {
-	change := NewInt16(0, false)
+	change := NewInt16(0, false, true)
 	assertNullInt16(t, change, "SetValid()")
 	change.SetValid(32766)
 	assertInt16(t, change, "SetValid()")

--- a/int32.go
+++ b/int32.go
@@ -16,7 +16,7 @@ import (
 type Int32 struct {
 	Int32 int32
 	Valid bool
-	set   bool
+	Set   bool
 }
 
 // NewInt32 creates a new Int32
@@ -24,7 +24,7 @@ func NewInt32(i int32, valid, set bool) Int32 {
 	return Int32{
 		Int32: i,
 		Valid: valid,
-		set:   set,
+		Set:   set,
 	}
 }
 
@@ -42,12 +42,12 @@ func Int32FromPtr(i *int32) Int32 {
 }
 
 func (i Int32) IsSet() bool {
-	return i.set
+	return i.Set
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (i *Int32) UnmarshalJSON(data []byte) error {
-	i.set = true
+	i.Set = true
 	if bytes.Equal(data, NullBytes) {
 		i.Valid = false
 		i.Int32 = 0
@@ -70,7 +70,7 @@ func (i *Int32) UnmarshalJSON(data []byte) error {
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (i *Int32) UnmarshalText(text []byte) error {
-	i.set = true
+	i.Set = true
 	if text == nil || len(text) == 0 {
 		i.Valid = false
 		return nil
@@ -104,7 +104,7 @@ func (i Int32) MarshalText() ([]byte, error) {
 func (i *Int32) SetValid(n int32) {
 	i.Int32 = n
 	i.Valid = true
-	i.set = true
+	i.Set = true
 }
 
 // Ptr returns a pointer to this Int32's value, or a nil pointer if this Int32 is null.
@@ -123,10 +123,10 @@ func (i Int32) IsZero() bool {
 // Scan implements the Scanner interface.
 func (i *Int32) Scan(value interface{}) error {
 	if value == nil {
-		i.Int32, i.Valid, i.set = 0, false, false
+		i.Int32, i.Valid, i.Set = 0, false, false
 		return nil
 	}
-	i.Valid, i.set = true, true
+	i.Valid, i.Set = true, true
 	return convert.ConvertAssign(&i.Int32, value)
 }
 

--- a/int32.go
+++ b/int32.go
@@ -8,7 +8,7 @@ import (
 	"math"
 	"strconv"
 
-	"github.com/volatiletech/null/v8/convert"
+	"github.com/razor-1/null/v9/convert"
 	"github.com/volatiletech/randomize"
 )
 
@@ -70,6 +70,7 @@ func (i *Int32) UnmarshalJSON(data []byte) error {
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (i *Int32) UnmarshalText(text []byte) error {
+	i.set = true
 	if text == nil || len(text) == 0 {
 		i.Valid = false
 		return nil
@@ -103,6 +104,7 @@ func (i Int32) MarshalText() ([]byte, error) {
 func (i *Int32) SetValid(n int32) {
 	i.Int32 = n
 	i.Valid = true
+	i.set = true
 }
 
 // Ptr returns a pointer to this Int32's value, or a nil pointer if this Int32 is null.
@@ -120,6 +122,7 @@ func (i Int32) IsZero() bool {
 
 // Scan implements the Scanner interface.
 func (i *Int32) Scan(value interface{}) error {
+	i.set = true
 	if value == nil {
 		i.Int32, i.Valid = 0, false
 		return nil

--- a/int32.go
+++ b/int32.go
@@ -20,25 +20,25 @@ type Int32 struct {
 }
 
 // NewInt32 creates a new Int32
-func NewInt32(i int32, valid, set bool) Int32 {
+func NewInt32(i int32, valid bool) Int32 {
 	return Int32{
 		Int32: i,
 		Valid: valid,
-		Set:   set,
+		Set:   true,
 	}
 }
 
 // Int32From creates a new Int32 that will always be valid.
 func Int32From(i int32) Int32 {
-	return NewInt32(i, true, true)
+	return NewInt32(i, true)
 }
 
 // Int32FromPtr creates a new Int32 that be null if i is nil.
 func Int32FromPtr(i *int32) Int32 {
 	if i == nil {
-		return NewInt32(0, false, true)
+		return NewInt32(0, false)
 	}
-	return NewInt32(*i, true, true)
+	return NewInt32(*i, true)
 }
 
 func (i Int32) IsSet() bool {

--- a/int32.go
+++ b/int32.go
@@ -122,12 +122,11 @@ func (i Int32) IsZero() bool {
 
 // Scan implements the Scanner interface.
 func (i *Int32) Scan(value interface{}) error {
-	i.set = true
 	if value == nil {
-		i.Int32, i.Valid = 0, false
+		i.Int32, i.Valid, i.set = 0, false, false
 		return nil
 	}
-	i.Valid = true
+	i.Valid, i.set = true, true
 	return convert.ConvertAssign(&i.Int32, value)
 }
 

--- a/int32.go
+++ b/int32.go
@@ -16,31 +16,38 @@ import (
 type Int32 struct {
 	Int32 int32
 	Valid bool
+	set   bool
 }
 
 // NewInt32 creates a new Int32
-func NewInt32(i int32, valid bool) Int32 {
+func NewInt32(i int32, valid, set bool) Int32 {
 	return Int32{
 		Int32: i,
 		Valid: valid,
+		set:   set,
 	}
 }
 
 // Int32From creates a new Int32 that will always be valid.
 func Int32From(i int32) Int32 {
-	return NewInt32(i, true)
+	return NewInt32(i, true, true)
 }
 
 // Int32FromPtr creates a new Int32 that be null if i is nil.
 func Int32FromPtr(i *int32) Int32 {
 	if i == nil {
-		return NewInt32(0, false)
+		return NewInt32(0, false, true)
 	}
-	return NewInt32(*i, true)
+	return NewInt32(*i, true, true)
+}
+
+func (i Int32) IsSet() bool {
+	return i.set
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (i *Int32) UnmarshalJSON(data []byte) error {
+	i.set = true
 	if bytes.Equal(data, NullBytes) {
 		i.Valid = false
 		i.Int32 = 0

--- a/int32_test.go
+++ b/int32_test.go
@@ -41,6 +41,9 @@ func TestUnmarshalInt32(t *testing.T) {
 	err = json.Unmarshal(nullJSON, &null)
 	maybePanic(err)
 	assertNullInt32(t, null, "null json")
+	if !null.set {
+		t.Error("should be set")
+	}
 
 	var badType Int32
 	err = json.Unmarshal(boolJSON, &badType)
@@ -100,7 +103,7 @@ func TestMarshalInt32(t *testing.T) {
 	assertJSONEquals(t, data, "2147483646", "non-empty json marshal")
 
 	// invalid values should be encoded as null
-	null := NewInt32(0, false)
+	null := NewInt32(0, false, true)
 	data, err = json.Marshal(null)
 	maybePanic(err)
 	assertJSONEquals(t, data, "null", "null json marshal")
@@ -113,7 +116,7 @@ func TestMarshalInt32Text(t *testing.T) {
 	assertJSONEquals(t, data, "2147483646", "non-empty text marshal")
 
 	// invalid values should be encoded as null
-	null := NewInt32(0, false)
+	null := NewInt32(0, false, true)
 	data, err = null.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "null text marshal")
@@ -126,7 +129,7 @@ func TestInt32Pointer(t *testing.T) {
 		t.Errorf("bad %s int32: %#v ≠ %d\n", "pointer", ptr, 2147483646)
 	}
 
-	null := NewInt32(0, false)
+	null := NewInt32(0, false, true)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s int32: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -139,19 +142,19 @@ func TestInt32IsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	null := NewInt32(0, false)
+	null := NewInt32(0, false, true)
 	if !null.IsZero() {
 		t.Errorf("IsZero() should be true")
 	}
 
-	zero := NewInt32(0, true)
+	zero := NewInt32(0, true, true)
 	if zero.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
 }
 
 func TestInt32SetValid(t *testing.T) {
-	change := NewInt32(0, false)
+	change := NewInt32(0, false, true)
 	assertNullInt32(t, change, "SetValid()")
 	change.SetValid(2147483646)
 	assertInt32(t, change, "SetValid()")

--- a/int32_test.go
+++ b/int32_test.go
@@ -103,7 +103,7 @@ func TestMarshalInt32(t *testing.T) {
 	assertJSONEquals(t, data, "2147483646", "non-empty json marshal")
 
 	// invalid values should be encoded as null
-	null := NewInt32(0, false, true)
+	null := NewInt32(0, false)
 	data, err = json.Marshal(null)
 	maybePanic(err)
 	assertJSONEquals(t, data, "null", "null json marshal")
@@ -116,7 +116,7 @@ func TestMarshalInt32Text(t *testing.T) {
 	assertJSONEquals(t, data, "2147483646", "non-empty text marshal")
 
 	// invalid values should be encoded as null
-	null := NewInt32(0, false, true)
+	null := NewInt32(0, false)
 	data, err = null.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "null text marshal")
@@ -129,7 +129,7 @@ func TestInt32Pointer(t *testing.T) {
 		t.Errorf("bad %s int32: %#v ≠ %d\n", "pointer", ptr, 2147483646)
 	}
 
-	null := NewInt32(0, false, true)
+	null := NewInt32(0, false)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s int32: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -142,19 +142,19 @@ func TestInt32IsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	null := NewInt32(0, false, true)
+	null := NewInt32(0, false)
 	if !null.IsZero() {
 		t.Errorf("IsZero() should be true")
 	}
 
-	zero := NewInt32(0, true, true)
+	zero := NewInt32(0, true)
 	if zero.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
 }
 
 func TestInt32SetValid(t *testing.T) {
-	change := NewInt32(0, false, true)
+	change := NewInt32(0, false)
 	assertNullInt32(t, change, "SetValid()")
 	change.SetValid(2147483646)
 	assertInt32(t, change, "SetValid()")

--- a/int32_test.go
+++ b/int32_test.go
@@ -41,8 +41,8 @@ func TestUnmarshalInt32(t *testing.T) {
 	err = json.Unmarshal(nullJSON, &null)
 	maybePanic(err)
 	assertNullInt32(t, null, "null json")
-	if !null.set {
-		t.Error("should be set")
+	if !null.Set {
+		t.Error("should be Set")
 	}
 
 	var badType Int32

--- a/int64.go
+++ b/int64.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"strconv"
 
-	"github.com/volatiletech/null/v8/convert"
+	"github.com/razor-1/null/v9/convert"
 )
 
 // Int64 is an nullable int64.
@@ -61,6 +61,7 @@ func (i *Int64) UnmarshalJSON(data []byte) error {
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (i *Int64) UnmarshalText(text []byte) error {
+	i.set = true
 	if text == nil || len(text) == 0 {
 		i.Valid = false
 		return nil
@@ -91,6 +92,7 @@ func (i Int64) MarshalText() ([]byte, error) {
 func (i *Int64) SetValid(n int64) {
 	i.Int64 = n
 	i.Valid = true
+	i.set = true
 }
 
 // Ptr returns a pointer to this Int64's value, or a nil pointer if this Int64 is null.
@@ -108,6 +110,7 @@ func (i Int64) IsZero() bool {
 
 // Scan implements the Scanner interface.
 func (i *Int64) Scan(value interface{}) error {
+	i.set = true
 	if value == nil {
 		i.Int64, i.Valid = 0, false
 		return nil

--- a/int64.go
+++ b/int64.go
@@ -110,12 +110,11 @@ func (i Int64) IsZero() bool {
 
 // Scan implements the Scanner interface.
 func (i *Int64) Scan(value interface{}) error {
-	i.set = true
 	if value == nil {
-		i.Int64, i.Valid = 0, false
+		i.Int64, i.Valid, i.set = 0, false, false
 		return nil
 	}
-	i.Valid = true
+	i.Valid, i.set = true, true
 	return convert.ConvertAssign(&i.Int64, value)
 }
 

--- a/int64.go
+++ b/int64.go
@@ -17,25 +17,25 @@ type Int64 struct {
 }
 
 // NewInt64 creates a new Int64
-func NewInt64(i int64, valid, set bool) Int64 {
+func NewInt64(i int64, valid bool) Int64 {
 	return Int64{
 		Int64: i,
 		Valid: valid,
-		Set:   set,
+		Set:   true,
 	}
 }
 
 // Int64From creates a new Int64 that will always be valid.
 func Int64From(i int64) Int64 {
-	return NewInt64(i, true, true)
+	return NewInt64(i, true)
 }
 
 // Int64FromPtr creates a new Int64 that be null if i is nil.
 func Int64FromPtr(i *int64) Int64 {
 	if i == nil {
-		return NewInt64(0, false, true)
+		return NewInt64(0, false)
 	}
-	return NewInt64(*i, true, true)
+	return NewInt64(*i, true)
 }
 
 func (i Int64) IsSet() bool {

--- a/int64.go
+++ b/int64.go
@@ -13,7 +13,7 @@ import (
 type Int64 struct {
 	Int64 int64
 	Valid bool
-	set   bool
+	Set   bool
 }
 
 // NewInt64 creates a new Int64
@@ -21,7 +21,7 @@ func NewInt64(i int64, valid, set bool) Int64 {
 	return Int64{
 		Int64: i,
 		Valid: valid,
-		set:   set,
+		Set:   set,
 	}
 }
 
@@ -39,12 +39,12 @@ func Int64FromPtr(i *int64) Int64 {
 }
 
 func (i Int64) IsSet() bool {
-	return i.set
+	return i.Set
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (i *Int64) UnmarshalJSON(data []byte) error {
-	i.set = true
+	i.Set = true
 	if bytes.Equal(data, NullBytes) {
 		i.Valid = false
 		i.Int64 = 0
@@ -61,7 +61,7 @@ func (i *Int64) UnmarshalJSON(data []byte) error {
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (i *Int64) UnmarshalText(text []byte) error {
-	i.set = true
+	i.Set = true
 	if text == nil || len(text) == 0 {
 		i.Valid = false
 		return nil
@@ -92,7 +92,7 @@ func (i Int64) MarshalText() ([]byte, error) {
 func (i *Int64) SetValid(n int64) {
 	i.Int64 = n
 	i.Valid = true
-	i.set = true
+	i.Set = true
 }
 
 // Ptr returns a pointer to this Int64's value, or a nil pointer if this Int64 is null.
@@ -111,10 +111,10 @@ func (i Int64) IsZero() bool {
 // Scan implements the Scanner interface.
 func (i *Int64) Scan(value interface{}) error {
 	if value == nil {
-		i.Int64, i.Valid, i.set = 0, false, false
+		i.Int64, i.Valid, i.Set = 0, false, false
 		return nil
 	}
-	i.Valid, i.set = true, true
+	i.Valid, i.Set = true, true
 	return convert.ConvertAssign(&i.Int64, value)
 }
 

--- a/int64.go
+++ b/int64.go
@@ -13,31 +13,38 @@ import (
 type Int64 struct {
 	Int64 int64
 	Valid bool
+	set   bool
 }
 
 // NewInt64 creates a new Int64
-func NewInt64(i int64, valid bool) Int64 {
+func NewInt64(i int64, valid, set bool) Int64 {
 	return Int64{
 		Int64: i,
 		Valid: valid,
+		set:   set,
 	}
 }
 
 // Int64From creates a new Int64 that will always be valid.
 func Int64From(i int64) Int64 {
-	return NewInt64(i, true)
+	return NewInt64(i, true, true)
 }
 
 // Int64FromPtr creates a new Int64 that be null if i is nil.
 func Int64FromPtr(i *int64) Int64 {
 	if i == nil {
-		return NewInt64(0, false)
+		return NewInt64(0, false, true)
 	}
-	return NewInt64(*i, true)
+	return NewInt64(*i, true, true)
+}
+
+func (i Int64) IsSet() bool {
+	return i.set
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (i *Int64) UnmarshalJSON(data []byte) error {
+	i.set = true
 	if bytes.Equal(data, NullBytes) {
 		i.Valid = false
 		i.Int64 = 0

--- a/int64_test.go
+++ b/int64_test.go
@@ -41,6 +41,9 @@ func TestUnmarshalInt64(t *testing.T) {
 	err = json.Unmarshal(nullJSON, &null)
 	maybePanic(err)
 	assertNullInt64(t, null, "null json")
+	if !null.set {
+		t.Error("should be set")
+	}
 
 	var badType Int64
 	err = json.Unmarshal(boolJSON, &badType)
@@ -100,7 +103,7 @@ func TestMarshalInt64(t *testing.T) {
 	assertJSONEquals(t, data, "9223372036854775806", "non-empty json marshal")
 
 	// invalid values should be encoded as null
-	null := NewInt64(0, false)
+	null := NewInt64(0, false, true)
 	data, err = json.Marshal(null)
 	maybePanic(err)
 	assertJSONEquals(t, data, "null", "null json marshal")
@@ -113,7 +116,7 @@ func TestMarshalInt64Text(t *testing.T) {
 	assertJSONEquals(t, data, "9223372036854775806", "non-empty text marshal")
 
 	// invalid values should be encoded as null
-	null := NewInt64(0, false)
+	null := NewInt64(0, false, true)
 	data, err = null.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "null text marshal")
@@ -126,7 +129,7 @@ func TestInt64Pointer(t *testing.T) {
 		t.Errorf("bad %s int64: %#v ≠ %d\n", "pointer", ptr, 9223372036854775806)
 	}
 
-	null := NewInt64(0, false)
+	null := NewInt64(0, false, true)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s int64: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -139,19 +142,19 @@ func TestInt64IsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	null := NewInt64(0, false)
+	null := NewInt64(0, false, true)
 	if !null.IsZero() {
 		t.Errorf("IsZero() should be true")
 	}
 
-	zero := NewInt64(0, true)
+	zero := NewInt64(0, true, true)
 	if zero.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
 }
 
 func TestInt64SetValid(t *testing.T) {
-	change := NewInt64(0, false)
+	change := NewInt64(0, false, true)
 	assertNullInt64(t, change, "SetValid()")
 	change.SetValid(9223372036854775806)
 	assertInt64(t, change, "SetValid()")

--- a/int64_test.go
+++ b/int64_test.go
@@ -41,8 +41,8 @@ func TestUnmarshalInt64(t *testing.T) {
 	err = json.Unmarshal(nullJSON, &null)
 	maybePanic(err)
 	assertNullInt64(t, null, "null json")
-	if !null.set {
-		t.Error("should be set")
+	if !null.Set {
+		t.Error("should be Set")
 	}
 
 	var badType Int64

--- a/int64_test.go
+++ b/int64_test.go
@@ -103,7 +103,7 @@ func TestMarshalInt64(t *testing.T) {
 	assertJSONEquals(t, data, "9223372036854775806", "non-empty json marshal")
 
 	// invalid values should be encoded as null
-	null := NewInt64(0, false, true)
+	null := NewInt64(0, false)
 	data, err = json.Marshal(null)
 	maybePanic(err)
 	assertJSONEquals(t, data, "null", "null json marshal")
@@ -116,7 +116,7 @@ func TestMarshalInt64Text(t *testing.T) {
 	assertJSONEquals(t, data, "9223372036854775806", "non-empty text marshal")
 
 	// invalid values should be encoded as null
-	null := NewInt64(0, false, true)
+	null := NewInt64(0, false)
 	data, err = null.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "null text marshal")
@@ -129,7 +129,7 @@ func TestInt64Pointer(t *testing.T) {
 		t.Errorf("bad %s int64: %#v ≠ %d\n", "pointer", ptr, 9223372036854775806)
 	}
 
-	null := NewInt64(0, false, true)
+	null := NewInt64(0, false)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s int64: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -142,19 +142,19 @@ func TestInt64IsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	null := NewInt64(0, false, true)
+	null := NewInt64(0, false)
 	if !null.IsZero() {
 		t.Errorf("IsZero() should be true")
 	}
 
-	zero := NewInt64(0, true, true)
+	zero := NewInt64(0, true)
 	if zero.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
 }
 
 func TestInt64SetValid(t *testing.T) {
-	change := NewInt64(0, false, true)
+	change := NewInt64(0, false)
 	assertNullInt64(t, change, "SetValid()")
 	change.SetValid(9223372036854775806)
 	assertInt64(t, change, "SetValid()")

--- a/int8.go
+++ b/int8.go
@@ -15,7 +15,7 @@ import (
 type Int8 struct {
 	Int8  int8
 	Valid bool
-	set   bool
+	Set   bool
 }
 
 // NewInt8 creates a new Int8
@@ -23,7 +23,7 @@ func NewInt8(i int8, valid, set bool) Int8 {
 	return Int8{
 		Int8:  i,
 		Valid: valid,
-		set:   set,
+		Set:   set,
 	}
 }
 
@@ -41,12 +41,12 @@ func Int8FromPtr(i *int8) Int8 {
 }
 
 func (i Int8) IsSet() bool {
-	return i.set
+	return i.Set
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (i *Int8) UnmarshalJSON(data []byte) error {
-	i.set = true
+	i.Set = true
 	if bytes.Equal(data, NullBytes) {
 		i.Valid = false
 		i.Int8 = 0
@@ -69,7 +69,7 @@ func (i *Int8) UnmarshalJSON(data []byte) error {
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (i *Int8) UnmarshalText(text []byte) error {
-	i.set = true
+	i.Set = true
 	if text == nil || len(text) == 0 {
 		i.Valid = false
 		return nil
@@ -103,7 +103,7 @@ func (i Int8) MarshalText() ([]byte, error) {
 func (i *Int8) SetValid(n int8) {
 	i.Int8 = n
 	i.Valid = true
-	i.set = true
+	i.Set = true
 }
 
 // Ptr returns a pointer to this Int8's value, or a nil pointer if this Int8 is null.
@@ -122,10 +122,10 @@ func (i Int8) IsZero() bool {
 // Scan implements the Scanner interface.
 func (i *Int8) Scan(value interface{}) error {
 	if value == nil {
-		i.Int8, i.Valid, i.set = 0, false, false
+		i.Int8, i.Valid, i.Set = 0, false, false
 		return nil
 	}
-	i.Valid, i.set = true, true
+	i.Valid, i.Set = true, true
 	return convert.ConvertAssign(&i.Int8, value)
 }
 

--- a/int8.go
+++ b/int8.go
@@ -15,31 +15,38 @@ import (
 type Int8 struct {
 	Int8  int8
 	Valid bool
+	set   bool
 }
 
 // NewInt8 creates a new Int8
-func NewInt8(i int8, valid bool) Int8 {
+func NewInt8(i int8, valid, set bool) Int8 {
 	return Int8{
 		Int8:  i,
 		Valid: valid,
+		set:   set,
 	}
 }
 
 // Int8From creates a new Int8 that will always be valid.
 func Int8From(i int8) Int8 {
-	return NewInt8(i, true)
+	return NewInt8(i, true, true)
 }
 
 // Int8FromPtr creates a new Int8 that be null if i is nil.
 func Int8FromPtr(i *int8) Int8 {
 	if i == nil {
-		return NewInt8(0, false)
+		return NewInt8(0, false, true)
 	}
-	return NewInt8(*i, true)
+	return NewInt8(*i, true, true)
+}
+
+func (i Int8) IsSet() bool {
+	return i.set
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (i *Int8) UnmarshalJSON(data []byte) error {
+	i.set = true
 	if bytes.Equal(data, NullBytes) {
 		i.Valid = false
 		i.Int8 = 0

--- a/int8.go
+++ b/int8.go
@@ -8,7 +8,7 @@ import (
 	"math"
 	"strconv"
 
-	"github.com/volatiletech/null/v8/convert"
+	"github.com/razor-1/null/v9/convert"
 )
 
 // Int8 is an nullable int8.
@@ -69,6 +69,7 @@ func (i *Int8) UnmarshalJSON(data []byte) error {
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (i *Int8) UnmarshalText(text []byte) error {
+	i.set = true
 	if text == nil || len(text) == 0 {
 		i.Valid = false
 		return nil
@@ -102,6 +103,7 @@ func (i Int8) MarshalText() ([]byte, error) {
 func (i *Int8) SetValid(n int8) {
 	i.Int8 = n
 	i.Valid = true
+	i.set = true
 }
 
 // Ptr returns a pointer to this Int8's value, or a nil pointer if this Int8 is null.
@@ -119,6 +121,7 @@ func (i Int8) IsZero() bool {
 
 // Scan implements the Scanner interface.
 func (i *Int8) Scan(value interface{}) error {
+	i.set = true
 	if value == nil {
 		i.Int8, i.Valid = 0, false
 		return nil

--- a/int8.go
+++ b/int8.go
@@ -121,12 +121,11 @@ func (i Int8) IsZero() bool {
 
 // Scan implements the Scanner interface.
 func (i *Int8) Scan(value interface{}) error {
-	i.set = true
 	if value == nil {
-		i.Int8, i.Valid = 0, false
+		i.Int8, i.Valid, i.set = 0, false, false
 		return nil
 	}
-	i.Valid = true
+	i.Valid, i.set = true, true
 	return convert.ConvertAssign(&i.Int8, value)
 }
 

--- a/int8.go
+++ b/int8.go
@@ -19,25 +19,25 @@ type Int8 struct {
 }
 
 // NewInt8 creates a new Int8
-func NewInt8(i int8, valid, set bool) Int8 {
+func NewInt8(i int8, valid bool) Int8 {
 	return Int8{
 		Int8:  i,
 		Valid: valid,
-		Set:   set,
+		Set:   true,
 	}
 }
 
 // Int8From creates a new Int8 that will always be valid.
 func Int8From(i int8) Int8 {
-	return NewInt8(i, true, true)
+	return NewInt8(i, true)
 }
 
 // Int8FromPtr creates a new Int8 that be null if i is nil.
 func Int8FromPtr(i *int8) Int8 {
 	if i == nil {
-		return NewInt8(0, false, true)
+		return NewInt8(0, false)
 	}
-	return NewInt8(*i, true, true)
+	return NewInt8(*i, true)
 }
 
 func (i Int8) IsSet() bool {

--- a/int8_test.go
+++ b/int8_test.go
@@ -41,8 +41,8 @@ func TestUnmarshalInt8(t *testing.T) {
 	err = json.Unmarshal(nullJSON, &null)
 	maybePanic(err)
 	assertNullInt8(t, null, "null json")
-	if !null.set {
-		t.Error("should be set")
+	if !null.Set {
+		t.Error("should be Set")
 	}
 
 	var badType Int8

--- a/int8_test.go
+++ b/int8_test.go
@@ -41,6 +41,9 @@ func TestUnmarshalInt8(t *testing.T) {
 	err = json.Unmarshal(nullJSON, &null)
 	maybePanic(err)
 	assertNullInt8(t, null, "null json")
+	if !null.set {
+		t.Error("should be set")
+	}
 
 	var badType Int8
 	err = json.Unmarshal(boolJSON, &badType)
@@ -100,7 +103,7 @@ func TestMarshalInt8(t *testing.T) {
 	assertJSONEquals(t, data, "126", "non-empty json marshal")
 
 	// invalid values should be encoded as null
-	null := NewInt8(0, false)
+	null := NewInt8(0, false, true)
 	data, err = json.Marshal(null)
 	maybePanic(err)
 	assertJSONEquals(t, data, "null", "null json marshal")
@@ -113,7 +116,7 @@ func TestMarshalInt8Text(t *testing.T) {
 	assertJSONEquals(t, data, "126", "non-empty text marshal")
 
 	// invalid values should be encoded as null
-	null := NewInt8(0, false)
+	null := NewInt8(0, false, true)
 	data, err = null.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "null text marshal")
@@ -126,7 +129,7 @@ func TestInt8Pointer(t *testing.T) {
 		t.Errorf("bad %s int8: %#v ≠ %d\n", "pointer", ptr, 126)
 	}
 
-	null := NewInt8(0, false)
+	null := NewInt8(0, false, true)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s int8: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -139,19 +142,19 @@ func TestInt8IsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	null := NewInt8(0, false)
+	null := NewInt8(0, false, true)
 	if !null.IsZero() {
 		t.Errorf("IsZero() should be true")
 	}
 
-	zero := NewInt8(0, true)
+	zero := NewInt8(0, true, true)
 	if zero.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
 }
 
 func TestInt8SetValid(t *testing.T) {
-	change := NewInt8(0, false)
+	change := NewInt8(0, false, true)
 	assertNullInt8(t, change, "SetValid()")
 	change.SetValid(126)
 	assertInt8(t, change, "SetValid()")

--- a/int8_test.go
+++ b/int8_test.go
@@ -103,7 +103,7 @@ func TestMarshalInt8(t *testing.T) {
 	assertJSONEquals(t, data, "126", "non-empty json marshal")
 
 	// invalid values should be encoded as null
-	null := NewInt8(0, false, true)
+	null := NewInt8(0, false)
 	data, err = json.Marshal(null)
 	maybePanic(err)
 	assertJSONEquals(t, data, "null", "null json marshal")
@@ -116,7 +116,7 @@ func TestMarshalInt8Text(t *testing.T) {
 	assertJSONEquals(t, data, "126", "non-empty text marshal")
 
 	// invalid values should be encoded as null
-	null := NewInt8(0, false, true)
+	null := NewInt8(0, false)
 	data, err = null.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "null text marshal")
@@ -129,7 +129,7 @@ func TestInt8Pointer(t *testing.T) {
 		t.Errorf("bad %s int8: %#v ≠ %d\n", "pointer", ptr, 126)
 	}
 
-	null := NewInt8(0, false, true)
+	null := NewInt8(0, false)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s int8: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -142,19 +142,19 @@ func TestInt8IsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	null := NewInt8(0, false, true)
+	null := NewInt8(0, false)
 	if !null.IsZero() {
 		t.Errorf("IsZero() should be true")
 	}
 
-	zero := NewInt8(0, true, true)
+	zero := NewInt8(0, true)
 	if zero.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
 }
 
 func TestInt8SetValid(t *testing.T) {
-	change := NewInt8(0, false, true)
+	change := NewInt8(0, false)
 	assertNullInt8(t, change, "SetValid()")
 	change.SetValid(126)
 	assertInt8(t, change, "SetValid()")

--- a/int_test.go
+++ b/int_test.go
@@ -85,7 +85,7 @@ func TestMarshalInt(t *testing.T) {
 	assertJSONEquals(t, data, "12345", "non-empty json marshal")
 
 	// invalid values should be encoded as null
-	null := NewInt(0, false, true)
+	null := NewInt(0, false)
 	data, err = json.Marshal(null)
 	maybePanic(err)
 	assertJSONEquals(t, data, "null", "null json marshal")
@@ -98,7 +98,7 @@ func TestMarshalIntText(t *testing.T) {
 	assertJSONEquals(t, data, "12345", "non-empty text marshal")
 
 	// invalid values should be encoded as null
-	null := NewInt(0, false, true)
+	null := NewInt(0, false)
 	data, err = null.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "null text marshal")
@@ -111,7 +111,7 @@ func TestIntPointer(t *testing.T) {
 		t.Errorf("bad %s int: %#v ≠ %d\n", "pointer", ptr, 12345)
 	}
 
-	null := NewInt(0, false, true)
+	null := NewInt(0, false)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s int: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -124,19 +124,19 @@ func TestIntIsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	null := NewInt(0, false, true)
+	null := NewInt(0, false)
 	if !null.IsZero() {
 		t.Errorf("IsZero() should be true")
 	}
 
-	zero := NewInt(0, true, true)
+	zero := NewInt(0, true)
 	if zero.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
 }
 
 func TestIntSetValid(t *testing.T) {
-	change := NewInt(0, false, true)
+	change := NewInt(0, false)
 	assertNullInt(t, change, "SetValid()")
 	change.SetValid(12345)
 	assertInt(t, change, "SetValid()")

--- a/int_test.go
+++ b/int_test.go
@@ -39,6 +39,9 @@ func TestUnmarshalInt(t *testing.T) {
 	err = json.Unmarshal(nullJSON, &null)
 	maybePanic(err)
 	assertNullInt(t, null, "null json")
+	if !null.set {
+		t.Error("is not set, but should be")
+	}
 
 	var badType Int
 	err = json.Unmarshal(boolJSON, &badType)
@@ -82,7 +85,7 @@ func TestMarshalInt(t *testing.T) {
 	assertJSONEquals(t, data, "12345", "non-empty json marshal")
 
 	// invalid values should be encoded as null
-	null := NewInt(0, false)
+	null := NewInt(0, false, true)
 	data, err = json.Marshal(null)
 	maybePanic(err)
 	assertJSONEquals(t, data, "null", "null json marshal")
@@ -95,7 +98,7 @@ func TestMarshalIntText(t *testing.T) {
 	assertJSONEquals(t, data, "12345", "non-empty text marshal")
 
 	// invalid values should be encoded as null
-	null := NewInt(0, false)
+	null := NewInt(0, false, true)
 	data, err = null.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "null text marshal")
@@ -108,7 +111,7 @@ func TestIntPointer(t *testing.T) {
 		t.Errorf("bad %s int: %#v ≠ %d\n", "pointer", ptr, 12345)
 	}
 
-	null := NewInt(0, false)
+	null := NewInt(0, false, true)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s int: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -121,19 +124,19 @@ func TestIntIsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	null := NewInt(0, false)
+	null := NewInt(0, false, true)
 	if !null.IsZero() {
 		t.Errorf("IsZero() should be true")
 	}
 
-	zero := NewInt(0, true)
+	zero := NewInt(0, true, true)
 	if zero.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
 }
 
 func TestIntSetValid(t *testing.T) {
-	change := NewInt(0, false)
+	change := NewInt(0, false, true)
 	assertNullInt(t, change, "SetValid()")
 	change.SetValid(12345)
 	assertInt(t, change, "SetValid()")

--- a/int_test.go
+++ b/int_test.go
@@ -39,8 +39,8 @@ func TestUnmarshalInt(t *testing.T) {
 	err = json.Unmarshal(nullJSON, &null)
 	maybePanic(err)
 	assertNullInt(t, null, "null json")
-	if !null.set {
-		t.Error("is not set, but should be")
+	if !null.Set {
+		t.Error("is not Set, but should be")
 	}
 
 	var badType Int

--- a/interface.go
+++ b/interface.go
@@ -1,0 +1,5 @@
+package null
+
+type Nullable interface {
+	IsSet() bool
+}

--- a/json.go
+++ b/json.go
@@ -150,12 +150,11 @@ func (j JSON) IsZero() bool {
 
 // Scan implements the Scanner interface.
 func (j *JSON) Scan(value interface{}) error {
-	j.set = true
 	if value == nil {
-		j.JSON, j.Valid = []byte{}, false
+		j.JSON, j.Valid, j.set = nil, false, false
 		return nil
 	}
-	j.Valid = true
+	j.Valid, j.set = true, true
 	return convert.ConvertAssign(&j.JSON, value)
 }
 

--- a/json.go
+++ b/json.go
@@ -15,7 +15,7 @@ import (
 type JSON struct {
 	JSON  []byte
 	Valid bool
-	set   bool
+	Set   bool
 }
 
 // NewJSON creates a new JSON
@@ -23,7 +23,7 @@ func NewJSON(b []byte, valid, set bool) JSON {
 	return JSON{
 		JSON:  b,
 		Valid: valid,
-		set:   set,
+		Set:   set,
 	}
 }
 
@@ -42,7 +42,7 @@ func JSONFromPtr(b *[]byte) JSON {
 }
 
 func (j JSON) IsSet() bool {
-	return j.set
+	return j.Set
 }
 
 // Unmarshal will unmarshal your JSON stored in
@@ -66,7 +66,7 @@ func (j JSON) Unmarshal(dest interface{}) error {
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (j *JSON) UnmarshalJSON(data []byte) error {
-	j.set = true
+	j.Set = true
 	if data == nil {
 		return fmt.Errorf("json: cannot unmarshal nil into Go value of type null.JSON")
 	}
@@ -86,7 +86,7 @@ func (j *JSON) UnmarshalJSON(data []byte) error {
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (j *JSON) UnmarshalText(text []byte) error {
-	j.set = true
+	j.Set = true
 	if text == nil || len(text) == 0 {
 		j.JSON = nil
 		j.Valid = false
@@ -108,7 +108,7 @@ func (j *JSON) Marshal(obj interface{}) error {
 
 	// Call our implementation of
 	// JSON UnmarshalJSON through json.Unmarshal
-	// to set the result to the JSON object
+	// to Set the result to the JSON object
 	return json.Unmarshal(res, j)
 }
 
@@ -132,7 +132,7 @@ func (j JSON) MarshalText() ([]byte, error) {
 func (j *JSON) SetValid(n []byte) {
 	j.JSON = n
 	j.Valid = true
-	j.set = true
+	j.Set = true
 }
 
 // Ptr returns a pointer to this JSON's value, or a nil pointer if this JSON is null.
@@ -151,10 +151,10 @@ func (j JSON) IsZero() bool {
 // Scan implements the Scanner interface.
 func (j *JSON) Scan(value interface{}) error {
 	if value == nil {
-		j.JSON, j.Valid, j.set = nil, false, false
+		j.JSON, j.Valid, j.Set = nil, false, false
 		return nil
 	}
-	j.Valid, j.set = true, true
+	j.Valid, j.Set = true, true
 	return convert.ConvertAssign(&j.JSON, value)
 }
 

--- a/json.go
+++ b/json.go
@@ -15,28 +15,34 @@ import (
 type JSON struct {
 	JSON  []byte
 	Valid bool
+	set   bool
 }
 
 // NewJSON creates a new JSON
-func NewJSON(b []byte, valid bool) JSON {
+func NewJSON(b []byte, valid, set bool) JSON {
 	return JSON{
 		JSON:  b,
 		Valid: valid,
+		set:   set,
 	}
 }
 
 // JSONFrom creates a new JSON that will be invalid if nil.
 func JSONFrom(b []byte) JSON {
-	return NewJSON(b, b != nil)
+	return NewJSON(b, b != nil, true)
 }
 
 // JSONFromPtr creates a new JSON that will be invalid if nil.
 func JSONFromPtr(b *[]byte) JSON {
 	if b == nil {
-		return NewJSON(nil, false)
+		return NewJSON(nil, false, true)
 	}
-	n := NewJSON(*b, true)
+	n := NewJSON(*b, true, true)
 	return n
+}
+
+func (j JSON) IsSet() bool {
+	return j.set
 }
 
 // Unmarshal will unmarshal your JSON stored in
@@ -60,6 +66,7 @@ func (j JSON) Unmarshal(dest interface{}) error {
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (j *JSON) UnmarshalJSON(data []byte) error {
+	j.set = true
 	if data == nil {
 		return fmt.Errorf("json: cannot unmarshal nil into Go value of type null.JSON")
 	}

--- a/json.go
+++ b/json.go
@@ -19,25 +19,25 @@ type JSON struct {
 }
 
 // NewJSON creates a new JSON
-func NewJSON(b []byte, valid, set bool) JSON {
+func NewJSON(b []byte, valid bool) JSON {
 	return JSON{
 		JSON:  b,
 		Valid: valid,
-		Set:   set,
+		Set:   true,
 	}
 }
 
 // JSONFrom creates a new JSON that will be invalid if nil.
 func JSONFrom(b []byte) JSON {
-	return NewJSON(b, b != nil, true)
+	return NewJSON(b, b != nil)
 }
 
 // JSONFromPtr creates a new JSON that will be invalid if nil.
 func JSONFromPtr(b *[]byte) JSON {
 	if b == nil {
-		return NewJSON(nil, false, true)
+		return NewJSON(nil, false)
 	}
-	n := NewJSON(*b, true, true)
+	n := NewJSON(*b, true)
 	return n
 }
 

--- a/json.go
+++ b/json.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/volatiletech/null/v8/convert"
+	"github.com/razor-1/null/v9/convert"
 	"github.com/volatiletech/randomize"
 )
 
@@ -86,6 +86,7 @@ func (j *JSON) UnmarshalJSON(data []byte) error {
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (j *JSON) UnmarshalText(text []byte) error {
+	j.set = true
 	if text == nil || len(text) == 0 {
 		j.JSON = nil
 		j.Valid = false
@@ -131,6 +132,7 @@ func (j JSON) MarshalText() ([]byte, error) {
 func (j *JSON) SetValid(n []byte) {
 	j.JSON = n
 	j.Valid = true
+	j.set = true
 }
 
 // Ptr returns a pointer to this JSON's value, or a nil pointer if this JSON is null.
@@ -148,6 +150,7 @@ func (j JSON) IsZero() bool {
 
 // Scan implements the Scanner interface.
 func (j *JSON) Scan(value interface{}) error {
+	j.set = true
 	if value == nil {
 		j.JSON, j.Valid = []byte{}, false
 		return nil

--- a/json_test.go
+++ b/json_test.go
@@ -150,7 +150,7 @@ func TestMarshalJSON(t *testing.T) {
 	assertJSONEquals(t, data, `"hello"`, "non-empty json marshal")
 
 	// invalid values should be encoded as null
-	null := NewJSON(nil, false, true)
+	null := NewJSON(nil, false)
 	data, err = json.Marshal(null)
 	maybePanic(err)
 	assertJSONEquals(t, data, "null", "null json marshal")
@@ -163,7 +163,7 @@ func TestMarshalJSONText(t *testing.T) {
 	assertJSONEquals(t, data, `"hello"`, "non-empty text marshal")
 
 	// invalid values should be encoded as null
-	null := NewJSON(nil, false, true)
+	null := NewJSON(nil, false)
 	data, err = null.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "null text marshal")
@@ -176,7 +176,7 @@ func TestJSONPointer(t *testing.T) {
 		t.Errorf("bad %s []byte: %#v ≠ %s\n", "pointer", ptr, `"hello"`)
 	}
 
-	null := NewJSON(nil, false, true)
+	null := NewJSON(nil, false)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s []byte: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -189,19 +189,19 @@ func TestJSONIsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	null := NewJSON(nil, false, true)
+	null := NewJSON(nil, false)
 	if !null.IsZero() {
 		t.Errorf("IsZero() should be true")
 	}
 
-	zero := NewJSON(nil, true, true)
+	zero := NewJSON(nil, true)
 	if zero.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
 }
 
 func TestJSONSetValid(t *testing.T) {
-	change := NewJSON(nil, false, true)
+	change := NewJSON(nil, false)
 	assertNullJSON(t, change, "SetValid()")
 	change.SetValid([]byte(`"hello"`))
 	assertJSON(t, change, "SetValid()")

--- a/json_test.go
+++ b/json_test.go
@@ -126,8 +126,8 @@ func TestUnmarshalJSON(t *testing.T) {
 	if !bytes.Equal(null.JSON, nil) {
 		t.Errorf("Expected JSON to be []byte nil, but was not: %#v %#v", null.JSON, []byte(nil))
 	}
-	if !null.set {
-		t.Error("should be set")
+	if !null.Set {
+		t.Error("should be Set")
 	}
 }
 

--- a/json_test.go
+++ b/json_test.go
@@ -126,6 +126,9 @@ func TestUnmarshalJSON(t *testing.T) {
 	if !bytes.Equal(null.JSON, nil) {
 		t.Errorf("Expected JSON to be []byte nil, but was not: %#v %#v", null.JSON, []byte(nil))
 	}
+	if !null.set {
+		t.Error("should be set")
+	}
 }
 
 func TestTextUnmarshalJSON(t *testing.T) {
@@ -147,7 +150,7 @@ func TestMarshalJSON(t *testing.T) {
 	assertJSONEquals(t, data, `"hello"`, "non-empty json marshal")
 
 	// invalid values should be encoded as null
-	null := NewJSON(nil, false)
+	null := NewJSON(nil, false, true)
 	data, err = json.Marshal(null)
 	maybePanic(err)
 	assertJSONEquals(t, data, "null", "null json marshal")
@@ -160,7 +163,7 @@ func TestMarshalJSONText(t *testing.T) {
 	assertJSONEquals(t, data, `"hello"`, "non-empty text marshal")
 
 	// invalid values should be encoded as null
-	null := NewJSON(nil, false)
+	null := NewJSON(nil, false, true)
 	data, err = null.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "null text marshal")
@@ -173,7 +176,7 @@ func TestJSONPointer(t *testing.T) {
 		t.Errorf("bad %s []byte: %#v ≠ %s\n", "pointer", ptr, `"hello"`)
 	}
 
-	null := NewJSON(nil, false)
+	null := NewJSON(nil, false, true)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s []byte: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -186,19 +189,19 @@ func TestJSONIsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	null := NewJSON(nil, false)
+	null := NewJSON(nil, false, true)
 	if !null.IsZero() {
 		t.Errorf("IsZero() should be true")
 	}
 
-	zero := NewJSON(nil, true)
+	zero := NewJSON(nil, true, true)
 	if zero.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
 }
 
 func TestJSONSetValid(t *testing.T) {
-	change := NewJSON(nil, false)
+	change := NewJSON(nil, false, true)
 	assertNullJSON(t, change, "SetValid()")
 	change.SetValid([]byte(`"hello"`))
 	assertJSON(t, change, "SetValid()")

--- a/string.go
+++ b/string.go
@@ -13,7 +13,7 @@ import (
 type String struct {
 	String string
 	Valid  bool
-	set    bool
+	Set    bool
 }
 
 // StringFrom creates a new String that will never be blank.
@@ -34,17 +34,17 @@ func NewString(s string, valid, set bool) String {
 	return String{
 		String: s,
 		Valid:  valid,
-		set:    set,
+		Set:    set,
 	}
 }
 
 func (s String) IsSet() bool {
-	return s.set
+	return s.Set
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (s *String) UnmarshalJSON(data []byte) error {
-	s.set = true
+	s.Set = true
 	if bytes.Equal(data, NullBytes) {
 		s.String = ""
 		s.Valid = false
@@ -77,7 +77,7 @@ func (s String) MarshalText() ([]byte, error) {
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (s *String) UnmarshalText(text []byte) error {
-	s.set = true
+	s.Set = true
 	if text == nil || len(text) == 0 {
 		s.Valid = false
 		return nil
@@ -92,7 +92,7 @@ func (s *String) UnmarshalText(text []byte) error {
 func (s *String) SetValid(v string) {
 	s.String = v
 	s.Valid = true
-	s.set = true
+	s.Set = true
 }
 
 // Ptr returns a pointer to this String's value, or a nil pointer if this String is null.
@@ -111,10 +111,10 @@ func (s String) IsZero() bool {
 // Scan implements the Scanner interface.
 func (s *String) Scan(value interface{}) error {
 	if value == nil {
-		s.String, s.Valid, s.set = "", false, false
+		s.String, s.Valid, s.Set = "", false, false
 		return nil
 	}
-	s.Valid, s.set = true, true
+	s.Valid, s.Set = true, true
 	return convert.ConvertAssign(&s.String, value)
 }
 

--- a/string.go
+++ b/string.go
@@ -13,31 +13,38 @@ import (
 type String struct {
 	String string
 	Valid  bool
+	set    bool
 }
 
 // StringFrom creates a new String that will never be blank.
 func StringFrom(s string) String {
-	return NewString(s, true)
+	return NewString(s, true, true)
 }
 
 // StringFromPtr creates a new String that be null if s is nil.
 func StringFromPtr(s *string) String {
 	if s == nil {
-		return NewString("", false)
+		return NewString("", false, true)
 	}
-	return NewString(*s, true)
+	return NewString(*s, true, true)
 }
 
 // NewString creates a new String
-func NewString(s string, valid bool) String {
+func NewString(s string, valid, set bool) String {
 	return String{
 		String: s,
 		Valid:  valid,
+		set:    set,
 	}
+}
+
+func (s String) IsSet() bool {
+	return s.set
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (s *String) UnmarshalJSON(data []byte) error {
+	s.set = true
 	if bytes.Equal(data, NullBytes) {
 		s.String = ""
 		s.Valid = false

--- a/string.go
+++ b/string.go
@@ -110,12 +110,11 @@ func (s String) IsZero() bool {
 
 // Scan implements the Scanner interface.
 func (s *String) Scan(value interface{}) error {
-	s.set = true
 	if value == nil {
-		s.String, s.Valid = "", false
+		s.String, s.Valid, s.set = "", false, false
 		return nil
 	}
-	s.Valid = true
+	s.Valid, s.set = true, true
 	return convert.ConvertAssign(&s.String, value)
 }
 

--- a/string.go
+++ b/string.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 
-	"github.com/volatiletech/null/v8/convert"
+	"github.com/razor-1/null/v9/convert"
 	"github.com/volatiletech/randomize"
 )
 
@@ -77,6 +77,7 @@ func (s String) MarshalText() ([]byte, error) {
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (s *String) UnmarshalText(text []byte) error {
+	s.set = true
 	if text == nil || len(text) == 0 {
 		s.Valid = false
 		return nil
@@ -91,6 +92,7 @@ func (s *String) UnmarshalText(text []byte) error {
 func (s *String) SetValid(v string) {
 	s.String = v
 	s.Valid = true
+	s.set = true
 }
 
 // Ptr returns a pointer to this String's value, or a nil pointer if this String is null.
@@ -108,6 +110,7 @@ func (s String) IsZero() bool {
 
 // Scan implements the Scanner interface.
 func (s *String) Scan(value interface{}) error {
+	s.set = true
 	if value == nil {
 		s.String, s.Valid = "", false
 		return nil

--- a/string.go
+++ b/string.go
@@ -18,23 +18,23 @@ type String struct {
 
 // StringFrom creates a new String that will never be blank.
 func StringFrom(s string) String {
-	return NewString(s, true, true)
+	return NewString(s, true)
 }
 
 // StringFromPtr creates a new String that be null if s is nil.
 func StringFromPtr(s *string) String {
 	if s == nil {
-		return NewString("", false, true)
+		return NewString("", false)
 	}
-	return NewString(*s, true, true)
+	return NewString(*s, true)
 }
 
 // NewString creates a new String
-func NewString(s string, valid, set bool) String {
+func NewString(s string, valid bool) String {
 	return String{
 		String: s,
 		Valid:  valid,
-		Set:    set,
+		Set:    true,
 	}
 }
 

--- a/string_test.go
+++ b/string_test.go
@@ -127,7 +127,7 @@ func TestStringPointer(t *testing.T) {
 		t.Errorf("bad %s string: %#v ≠ %s\n", "pointer", ptr, "test")
 	}
 
-	null := NewString("", false, true)
+	null := NewString("", false)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s string: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -145,7 +145,7 @@ func TestStringIsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	empty := NewString("", true, true)
+	empty := NewString("", true)
 	if empty.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
@@ -157,7 +157,7 @@ func TestStringIsZero(t *testing.T) {
 }
 
 func TestStringSetValid(t *testing.T) {
-	change := NewString("", false, true)
+	change := NewString("", false)
 	assertNullStr(t, change, "SetValid()")
 	change.SetValid("test")
 	assertStr(t, change, "SetValid()")

--- a/string_test.go
+++ b/string_test.go
@@ -54,8 +54,8 @@ func TestUnmarshalString(t *testing.T) {
 	err = json.Unmarshal(nullJSON, &null)
 	maybePanic(err)
 	assertNullStr(t, null, "null json")
-	if !null.set {
-		t.Error("should be set")
+	if !null.Set {
+		t.Error("should be Set")
 	}
 
 	var badType String

--- a/string_test.go
+++ b/string_test.go
@@ -54,6 +54,9 @@ func TestUnmarshalString(t *testing.T) {
 	err = json.Unmarshal(nullJSON, &null)
 	maybePanic(err)
 	assertNullStr(t, null, "null json")
+	if !null.set {
+		t.Error("should be set")
+	}
 
 	var badType String
 	err = json.Unmarshal(boolJSON, &badType)
@@ -124,7 +127,7 @@ func TestStringPointer(t *testing.T) {
 		t.Errorf("bad %s string: %#v ≠ %s\n", "pointer", ptr, "test")
 	}
 
-	null := NewString("", false)
+	null := NewString("", false, true)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s string: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -142,7 +145,7 @@ func TestStringIsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	empty := NewString("", true)
+	empty := NewString("", true, true)
 	if empty.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
@@ -154,7 +157,7 @@ func TestStringIsZero(t *testing.T) {
 }
 
 func TestStringSetValid(t *testing.T) {
-	change := NewString("", false)
+	change := NewString("", false, true)
 	assertNullStr(t, change, "SetValid()")
 	change.SetValid("test")
 	assertStr(t, change, "SetValid()")

--- a/time.go
+++ b/time.go
@@ -111,18 +111,19 @@ func (t Time) IsZero() bool {
 
 // Scan implements the Scanner interface.
 func (t *Time) Scan(value interface{}) error {
-	t.set = true
 	var err error
 	switch x := value.(type) {
 	case time.Time:
 		t.Time = x
 	case nil:
-		t.Valid = false
+		t.Valid, t.set = false, false
 		return nil
 	default:
 		err = fmt.Errorf("null: cannot scan type %T into null.Time: %v", value, value)
 	}
-	t.Valid = err == nil
+	if err == nil {
+		t.Valid, t.set = true, true
+	}
 	return err
 }
 

--- a/time.go
+++ b/time.go
@@ -13,7 +13,7 @@ import (
 type Time struct {
 	Time  time.Time
 	Valid bool
-	set   bool
+	Set   bool
 }
 
 // NewTime creates a new Time.
@@ -21,7 +21,7 @@ func NewTime(t time.Time, valid, set bool) Time {
 	return Time{
 		Time:  t,
 		Valid: valid,
-		set:   set,
+		Set:   set,
 	}
 }
 
@@ -39,7 +39,7 @@ func TimeFromPtr(t *time.Time) Time {
 }
 
 func (t Time) IsSet() bool {
-	return t.set
+	return t.Set
 }
 
 // MarshalJSON implements json.Marshaler.
@@ -52,7 +52,7 @@ func (t Time) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (t *Time) UnmarshalJSON(data []byte) error {
-	t.set = true
+	t.Set = true
 	if bytes.Equal(data, NullBytes) {
 		t.Valid = false
 		t.Time = time.Time{}
@@ -77,7 +77,7 @@ func (t Time) MarshalText() ([]byte, error) {
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (t *Time) UnmarshalText(text []byte) error {
-	t.set = true
+	t.Set = true
 	if text == nil || len(text) == 0 {
 		t.Valid = false
 		return nil
@@ -93,7 +93,7 @@ func (t *Time) UnmarshalText(text []byte) error {
 func (t *Time) SetValid(v time.Time) {
 	t.Time = v
 	t.Valid = true
-	t.set = true
+	t.Set = true
 }
 
 // Ptr returns a pointer to this Time's value, or a nil pointer if this Time is null.
@@ -116,13 +116,13 @@ func (t *Time) Scan(value interface{}) error {
 	case time.Time:
 		t.Time = x
 	case nil:
-		t.Valid, t.set = false, false
+		t.Valid, t.Set = false, false
 		return nil
 	default:
 		err = fmt.Errorf("null: cannot scan type %T into null.Time: %v", value, value)
 	}
 	if err == nil {
-		t.Valid, t.set = true, true
+		t.Valid, t.Set = true, true
 	}
 	return err
 }

--- a/time.go
+++ b/time.go
@@ -17,25 +17,25 @@ type Time struct {
 }
 
 // NewTime creates a new Time.
-func NewTime(t time.Time, valid, set bool) Time {
+func NewTime(t time.Time, valid bool) Time {
 	return Time{
 		Time:  t,
 		Valid: valid,
-		Set:   set,
+		Set:   true,
 	}
 }
 
 // TimeFrom creates a new Time that will always be valid.
 func TimeFrom(t time.Time) Time {
-	return NewTime(t, true, true)
+	return NewTime(t, true)
 }
 
 // TimeFromPtr creates a new Time that will be null if t is nil.
 func TimeFromPtr(t *time.Time) Time {
 	if t == nil {
-		return NewTime(time.Time{}, false, true)
+		return NewTime(time.Time{}, false)
 	}
-	return NewTime(*t, true, true)
+	return NewTime(*t, true)
 }
 
 func (t Time) IsSet() bool {

--- a/time.go
+++ b/time.go
@@ -13,27 +13,33 @@ import (
 type Time struct {
 	Time  time.Time
 	Valid bool
+	set   bool
 }
 
 // NewTime creates a new Time.
-func NewTime(t time.Time, valid bool) Time {
+func NewTime(t time.Time, valid, set bool) Time {
 	return Time{
 		Time:  t,
 		Valid: valid,
+		set:   set,
 	}
 }
 
 // TimeFrom creates a new Time that will always be valid.
 func TimeFrom(t time.Time) Time {
-	return NewTime(t, true)
+	return NewTime(t, true, true)
 }
 
 // TimeFromPtr creates a new Time that will be null if t is nil.
 func TimeFromPtr(t *time.Time) Time {
 	if t == nil {
-		return NewTime(time.Time{}, false)
+		return NewTime(time.Time{}, false, true)
 	}
-	return NewTime(*t, true)
+	return NewTime(*t, true, true)
+}
+
+func (t Time) IsSet() bool {
+	return t.set
 }
 
 // MarshalJSON implements json.Marshaler.
@@ -46,6 +52,7 @@ func (t Time) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (t *Time) UnmarshalJSON(data []byte) error {
+	t.set = true
 	if bytes.Equal(data, NullBytes) {
 		t.Valid = false
 		t.Time = time.Time{}

--- a/time.go
+++ b/time.go
@@ -77,6 +77,7 @@ func (t Time) MarshalText() ([]byte, error) {
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (t *Time) UnmarshalText(text []byte) error {
+	t.set = true
 	if text == nil || len(text) == 0 {
 		t.Valid = false
 		return nil
@@ -92,6 +93,7 @@ func (t *Time) UnmarshalText(text []byte) error {
 func (t *Time) SetValid(v time.Time) {
 	t.Time = v
 	t.Valid = true
+	t.set = true
 }
 
 // Ptr returns a pointer to this Time's value, or a nil pointer if this Time is null.
@@ -109,6 +111,7 @@ func (t Time) IsZero() bool {
 
 // Scan implements the Scanner interface.
 func (t *Time) Scan(value interface{}) error {
+	t.set = true
 	var err error
 	switch x := value.(type) {
 	case time.Time:

--- a/time_test.go
+++ b/time_test.go
@@ -96,7 +96,7 @@ func TestTimeFromPtr(t *testing.T) {
 
 func TestTimeSetValid(t *testing.T) {
 	var ti time.Time
-	change := NewTime(ti, false, true)
+	change := NewTime(ti, false)
 	assertNullTime(t, change, "SetValid()")
 	change.SetValid(timeValue)
 	assertTime(t, change, "SetValid()")
@@ -110,7 +110,7 @@ func TestTimePointer(t *testing.T) {
 	}
 
 	var nt time.Time
-	null := NewTime(nt, false, true)
+	null := NewTime(nt, false)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s time: %#v ≠ %s\n", "nil pointer", ptr, "nil")

--- a/time_test.go
+++ b/time_test.go
@@ -24,6 +24,9 @@ func TestUnmarshalTimeJSON(t *testing.T) {
 	err = json.Unmarshal(nullTimeJSON, &null)
 	maybePanic(err)
 	assertNullTime(t, null, "null time json")
+	if !null.set {
+		t.Error("should be set")
+	}
 
 	var invalid Time
 	err = invalid.UnmarshalJSON(invalidJSON)
@@ -93,7 +96,7 @@ func TestTimeFromPtr(t *testing.T) {
 
 func TestTimeSetValid(t *testing.T) {
 	var ti time.Time
-	change := NewTime(ti, false)
+	change := NewTime(ti, false, true)
 	assertNullTime(t, change, "SetValid()")
 	change.SetValid(timeValue)
 	assertTime(t, change, "SetValid()")
@@ -107,7 +110,7 @@ func TestTimePointer(t *testing.T) {
 	}
 
 	var nt time.Time
-	null := NewTime(nt, false)
+	null := NewTime(nt, false, true)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s time: %#v ≠ %s\n", "nil pointer", ptr, "nil")

--- a/time_test.go
+++ b/time_test.go
@@ -24,8 +24,8 @@ func TestUnmarshalTimeJSON(t *testing.T) {
 	err = json.Unmarshal(nullTimeJSON, &null)
 	maybePanic(err)
 	assertNullTime(t, null, "null time json")
-	if !null.set {
-		t.Error("should be set")
+	if !null.Set {
+		t.Error("should be Set")
 	}
 
 	var invalid Time

--- a/uint.go
+++ b/uint.go
@@ -13,31 +13,38 @@ import (
 type Uint struct {
 	Uint  uint
 	Valid bool
+	set   bool
 }
 
 // NewUint creates a new Uint
-func NewUint(i uint, valid bool) Uint {
+func NewUint(i uint, valid, set bool) Uint {
 	return Uint{
 		Uint:  i,
 		Valid: valid,
+		set:   set,
 	}
 }
 
 // UintFrom creates a new Uint that will always be valid.
 func UintFrom(i uint) Uint {
-	return NewUint(i, true)
+	return NewUint(i, true, true)
 }
 
 // UintFromPtr creates a new Uint that be null if i is nil.
 func UintFromPtr(i *uint) Uint {
 	if i == nil {
-		return NewUint(0, false)
+		return NewUint(0, false, true)
 	}
-	return NewUint(*i, true)
+	return NewUint(*i, true, true)
+}
+
+func (u Uint) IsSet() bool {
+	return u.set
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (u *Uint) UnmarshalJSON(data []byte) error {
+	u.set = true
 	if bytes.Equal(data, NullBytes) {
 		u.Valid = false
 		u.Uint = 0

--- a/uint.go
+++ b/uint.go
@@ -115,12 +115,11 @@ func (u Uint) IsZero() bool {
 
 // Scan implements the Scanner interface.
 func (u *Uint) Scan(value interface{}) error {
-	u.set = true
 	if value == nil {
-		u.Uint, u.Valid = 0, false
+		u.Uint, u.Valid, u.set = 0, false, false
 		return nil
 	}
-	u.Valid = true
+	u.Valid, u.set = true, true
 	return convert.ConvertAssign(&u.Uint, value)
 }
 

--- a/uint.go
+++ b/uint.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"strconv"
 
-	"github.com/volatiletech/null/v8/convert"
+	"github.com/razor-1/null/v9/convert"
 )
 
 // Uint is an nullable uint.
@@ -63,6 +63,7 @@ func (u *Uint) UnmarshalJSON(data []byte) error {
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (u *Uint) UnmarshalText(text []byte) error {
+	u.set = true
 	if text == nil || len(text) == 0 {
 		u.Valid = false
 		return nil
@@ -96,6 +97,7 @@ func (u Uint) MarshalText() ([]byte, error) {
 func (u *Uint) SetValid(n uint) {
 	u.Uint = n
 	u.Valid = true
+	u.set = true
 }
 
 // Ptr returns a pointer to this Uint's value, or a nil pointer if this Uint is null.
@@ -113,6 +115,7 @@ func (u Uint) IsZero() bool {
 
 // Scan implements the Scanner interface.
 func (u *Uint) Scan(value interface{}) error {
+	u.set = true
 	if value == nil {
 		u.Uint, u.Valid = 0, false
 		return nil

--- a/uint.go
+++ b/uint.go
@@ -17,25 +17,25 @@ type Uint struct {
 }
 
 // NewUint creates a new Uint
-func NewUint(i uint, valid, set bool) Uint {
+func NewUint(i uint, valid bool) Uint {
 	return Uint{
 		Uint:  i,
 		Valid: valid,
-		Set:   set,
+		Set:   true,
 	}
 }
 
 // UintFrom creates a new Uint that will always be valid.
 func UintFrom(i uint) Uint {
-	return NewUint(i, true, true)
+	return NewUint(i, true)
 }
 
 // UintFromPtr creates a new Uint that be null if i is nil.
 func UintFromPtr(i *uint) Uint {
 	if i == nil {
-		return NewUint(0, false, true)
+		return NewUint(0, false)
 	}
-	return NewUint(*i, true, true)
+	return NewUint(*i, true)
 }
 
 func (u Uint) IsSet() bool {

--- a/uint.go
+++ b/uint.go
@@ -13,7 +13,7 @@ import (
 type Uint struct {
 	Uint  uint
 	Valid bool
-	set   bool
+	Set   bool
 }
 
 // NewUint creates a new Uint
@@ -21,7 +21,7 @@ func NewUint(i uint, valid, set bool) Uint {
 	return Uint{
 		Uint:  i,
 		Valid: valid,
-		set:   set,
+		Set:   set,
 	}
 }
 
@@ -39,12 +39,12 @@ func UintFromPtr(i *uint) Uint {
 }
 
 func (u Uint) IsSet() bool {
-	return u.set
+	return u.Set
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (u *Uint) UnmarshalJSON(data []byte) error {
-	u.set = true
+	u.Set = true
 	if bytes.Equal(data, NullBytes) {
 		u.Valid = false
 		u.Uint = 0
@@ -63,7 +63,7 @@ func (u *Uint) UnmarshalJSON(data []byte) error {
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (u *Uint) UnmarshalText(text []byte) error {
-	u.set = true
+	u.Set = true
 	if text == nil || len(text) == 0 {
 		u.Valid = false
 		return nil
@@ -97,7 +97,7 @@ func (u Uint) MarshalText() ([]byte, error) {
 func (u *Uint) SetValid(n uint) {
 	u.Uint = n
 	u.Valid = true
-	u.set = true
+	u.Set = true
 }
 
 // Ptr returns a pointer to this Uint's value, or a nil pointer if this Uint is null.
@@ -116,10 +116,10 @@ func (u Uint) IsZero() bool {
 // Scan implements the Scanner interface.
 func (u *Uint) Scan(value interface{}) error {
 	if value == nil {
-		u.Uint, u.Valid, u.set = 0, false, false
+		u.Uint, u.Valid, u.Set = 0, false, false
 		return nil
 	}
-	u.Valid, u.set = true, true
+	u.Valid, u.Set = true, true
 	return convert.ConvertAssign(&u.Uint, value)
 }
 

--- a/uint16.go
+++ b/uint16.go
@@ -15,31 +15,38 @@ import (
 type Uint16 struct {
 	Uint16 uint16
 	Valid  bool
+	set    bool
 }
 
 // NewUint16 creates a new Uint16
-func NewUint16(i uint16, valid bool) Uint16 {
+func NewUint16(i uint16, valid, set bool) Uint16 {
 	return Uint16{
 		Uint16: i,
 		Valid:  valid,
+		set:    set,
 	}
 }
 
 // Uint16From creates a new Uint16 that will always be valid.
 func Uint16From(i uint16) Uint16 {
-	return NewUint16(i, true)
+	return NewUint16(i, true, true)
 }
 
 // Uint16FromPtr creates a new Uint16 that be null if i is nil.
 func Uint16FromPtr(i *uint16) Uint16 {
 	if i == nil {
-		return NewUint16(0, false)
+		return NewUint16(0, false, true)
 	}
-	return NewUint16(*i, true)
+	return NewUint16(*i, true, true)
+}
+
+func (u Uint16) IsSet() bool {
+	return u.set
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (u *Uint16) UnmarshalJSON(data []byte) error {
+	u.set = true
 	if bytes.Equal(data, NullBytes) {
 		u.Valid = false
 		u.Uint16 = 0

--- a/uint16.go
+++ b/uint16.go
@@ -19,25 +19,25 @@ type Uint16 struct {
 }
 
 // NewUint16 creates a new Uint16
-func NewUint16(i uint16, valid, set bool) Uint16 {
+func NewUint16(i uint16, valid bool) Uint16 {
 	return Uint16{
 		Uint16: i,
 		Valid:  valid,
-		Set:    set,
+		Set:    true,
 	}
 }
 
 // Uint16From creates a new Uint16 that will always be valid.
 func Uint16From(i uint16) Uint16 {
-	return NewUint16(i, true, true)
+	return NewUint16(i, true)
 }
 
 // Uint16FromPtr creates a new Uint16 that be null if i is nil.
 func Uint16FromPtr(i *uint16) Uint16 {
 	if i == nil {
-		return NewUint16(0, false, true)
+		return NewUint16(0, false)
 	}
-	return NewUint16(*i, true, true)
+	return NewUint16(*i, true)
 }
 
 func (u Uint16) IsSet() bool {

--- a/uint16.go
+++ b/uint16.go
@@ -15,7 +15,7 @@ import (
 type Uint16 struct {
 	Uint16 uint16
 	Valid  bool
-	set    bool
+	Set    bool
 }
 
 // NewUint16 creates a new Uint16
@@ -23,7 +23,7 @@ func NewUint16(i uint16, valid, set bool) Uint16 {
 	return Uint16{
 		Uint16: i,
 		Valid:  valid,
-		set:    set,
+		Set:    set,
 	}
 }
 
@@ -41,12 +41,12 @@ func Uint16FromPtr(i *uint16) Uint16 {
 }
 
 func (u Uint16) IsSet() bool {
-	return u.set
+	return u.Set
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (u *Uint16) UnmarshalJSON(data []byte) error {
-	u.set = true
+	u.Set = true
 	if bytes.Equal(data, NullBytes) {
 		u.Valid = false
 		u.Uint16 = 0
@@ -69,7 +69,7 @@ func (u *Uint16) UnmarshalJSON(data []byte) error {
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (u *Uint16) UnmarshalText(text []byte) error {
-	u.set = true
+	u.Set = true
 	if text == nil || len(text) == 0 {
 		u.Valid = false
 		return nil
@@ -103,7 +103,7 @@ func (u Uint16) MarshalText() ([]byte, error) {
 func (u *Uint16) SetValid(n uint16) {
 	u.Uint16 = n
 	u.Valid = true
-	u.set = true
+	u.Set = true
 }
 
 // Ptr returns a pointer to this Uint16's value, or a nil pointer if this Uint16 is null.
@@ -122,10 +122,10 @@ func (u Uint16) IsZero() bool {
 // Scan implements the Scanner interface.
 func (u *Uint16) Scan(value interface{}) error {
 	if value == nil {
-		u.Uint16, u.Valid, u.set = 0, false, false
+		u.Uint16, u.Valid, u.Set = 0, false, false
 		return nil
 	}
-	u.Valid, u.set = true, true
+	u.Valid, u.Set = true, true
 	return convert.ConvertAssign(&u.Uint16, value)
 }
 

--- a/uint16.go
+++ b/uint16.go
@@ -121,12 +121,11 @@ func (u Uint16) IsZero() bool {
 
 // Scan implements the Scanner interface.
 func (u *Uint16) Scan(value interface{}) error {
-	u.set = true
 	if value == nil {
-		u.Uint16, u.Valid = 0, false
+		u.Uint16, u.Valid, u.set = 0, false, false
 		return nil
 	}
-	u.Valid = true
+	u.Valid, u.set = true, true
 	return convert.ConvertAssign(&u.Uint16, value)
 }
 

--- a/uint16.go
+++ b/uint16.go
@@ -8,7 +8,7 @@ import (
 	"math"
 	"strconv"
 
-	"github.com/volatiletech/null/v8/convert"
+	"github.com/razor-1/null/v9/convert"
 )
 
 // Uint16 is an nullable uint16.
@@ -69,6 +69,7 @@ func (u *Uint16) UnmarshalJSON(data []byte) error {
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (u *Uint16) UnmarshalText(text []byte) error {
+	u.set = true
 	if text == nil || len(text) == 0 {
 		u.Valid = false
 		return nil
@@ -102,6 +103,7 @@ func (u Uint16) MarshalText() ([]byte, error) {
 func (u *Uint16) SetValid(n uint16) {
 	u.Uint16 = n
 	u.Valid = true
+	u.set = true
 }
 
 // Ptr returns a pointer to this Uint16's value, or a nil pointer if this Uint16 is null.
@@ -119,6 +121,7 @@ func (u Uint16) IsZero() bool {
 
 // Scan implements the Scanner interface.
 func (u *Uint16) Scan(value interface{}) error {
+	u.set = true
 	if value == nil {
 		u.Uint16, u.Valid = 0, false
 		return nil

--- a/uint16_test.go
+++ b/uint16_test.go
@@ -41,8 +41,8 @@ func TestUnmarshalUint16(t *testing.T) {
 	err = json.Unmarshal(nullJSON, &null)
 	maybePanic(err)
 	assertNullUint16(t, null, "null json")
-	if !null.set {
-		t.Error("should be set")
+	if !null.Set {
+		t.Error("should be Set")
 	}
 
 	var badType Uint16

--- a/uint16_test.go
+++ b/uint16_test.go
@@ -103,7 +103,7 @@ func TestMarshalUint16(t *testing.T) {
 	assertJSONEquals(t, data, "65534", "non-empty json marshal")
 
 	// invalid values should be encoded as null
-	null := NewUint16(0, false, true)
+	null := NewUint16(0, false)
 	data, err = json.Marshal(null)
 	maybePanic(err)
 	assertJSONEquals(t, data, "null", "null json marshal")
@@ -116,7 +116,7 @@ func TestMarshalUint16Text(t *testing.T) {
 	assertJSONEquals(t, data, "65534", "non-empty text marshal")
 
 	// invalid values should be encoded as null
-	null := NewUint16(0, false, true)
+	null := NewUint16(0, false)
 	data, err = null.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "null text marshal")
@@ -129,7 +129,7 @@ func TestUint16Pointer(t *testing.T) {
 		t.Errorf("bad %s uint16: %#v ≠ %d\n", "pointer", ptr, 65534)
 	}
 
-	null := NewUint16(0, false, true)
+	null := NewUint16(0, false)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s uint16: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -142,19 +142,19 @@ func TestUint16IsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	null := NewUint16(0, false, true)
+	null := NewUint16(0, false)
 	if !null.IsZero() {
 		t.Errorf("IsZero() should be true")
 	}
 
-	zero := NewUint16(0, true, true)
+	zero := NewUint16(0, true)
 	if zero.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
 }
 
 func TestUint16SetValid(t *testing.T) {
-	change := NewUint16(0, false, true)
+	change := NewUint16(0, false)
 	assertNullUint16(t, change, "SetValid()")
 	change.SetValid(65534)
 	assertUint16(t, change, "SetValid()")

--- a/uint16_test.go
+++ b/uint16_test.go
@@ -41,6 +41,9 @@ func TestUnmarshalUint16(t *testing.T) {
 	err = json.Unmarshal(nullJSON, &null)
 	maybePanic(err)
 	assertNullUint16(t, null, "null json")
+	if !null.set {
+		t.Error("should be set")
+	}
 
 	var badType Uint16
 	err = json.Unmarshal(boolJSON, &badType)
@@ -100,7 +103,7 @@ func TestMarshalUint16(t *testing.T) {
 	assertJSONEquals(t, data, "65534", "non-empty json marshal")
 
 	// invalid values should be encoded as null
-	null := NewUint16(0, false)
+	null := NewUint16(0, false, true)
 	data, err = json.Marshal(null)
 	maybePanic(err)
 	assertJSONEquals(t, data, "null", "null json marshal")
@@ -113,7 +116,7 @@ func TestMarshalUint16Text(t *testing.T) {
 	assertJSONEquals(t, data, "65534", "non-empty text marshal")
 
 	// invalid values should be encoded as null
-	null := NewUint16(0, false)
+	null := NewUint16(0, false, true)
 	data, err = null.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "null text marshal")
@@ -126,7 +129,7 @@ func TestUint16Pointer(t *testing.T) {
 		t.Errorf("bad %s uint16: %#v ≠ %d\n", "pointer", ptr, 65534)
 	}
 
-	null := NewUint16(0, false)
+	null := NewUint16(0, false, true)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s uint16: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -139,19 +142,19 @@ func TestUint16IsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	null := NewUint16(0, false)
+	null := NewUint16(0, false, true)
 	if !null.IsZero() {
 		t.Errorf("IsZero() should be true")
 	}
 
-	zero := NewUint16(0, true)
+	zero := NewUint16(0, true, true)
 	if zero.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
 }
 
 func TestUint16SetValid(t *testing.T) {
-	change := NewUint16(0, false)
+	change := NewUint16(0, false, true)
 	assertNullUint16(t, change, "SetValid()")
 	change.SetValid(65534)
 	assertUint16(t, change, "SetValid()")

--- a/uint32.go
+++ b/uint32.go
@@ -8,7 +8,7 @@ import (
 	"math"
 	"strconv"
 
-	"github.com/volatiletech/null/v8/convert"
+	"github.com/razor-1/null/v9/convert"
 )
 
 // Uint32 is an nullable uint32.
@@ -69,6 +69,7 @@ func (u *Uint32) UnmarshalJSON(data []byte) error {
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (u *Uint32) UnmarshalText(text []byte) error {
+	u.set = true
 	if text == nil || len(text) == 0 {
 		u.Valid = false
 		return nil
@@ -102,6 +103,7 @@ func (u Uint32) MarshalText() ([]byte, error) {
 func (u *Uint32) SetValid(n uint32) {
 	u.Uint32 = n
 	u.Valid = true
+	u.set = true
 }
 
 // Ptr returns a pointer to this Uint32's value, or a nil pointer if this Uint32 is null.
@@ -119,6 +121,7 @@ func (u Uint32) IsZero() bool {
 
 // Scan implements the Scanner interface.
 func (u *Uint32) Scan(value interface{}) error {
+	u.set = true
 	if value == nil {
 		u.Uint32, u.Valid = 0, false
 		return nil

--- a/uint32.go
+++ b/uint32.go
@@ -121,12 +121,11 @@ func (u Uint32) IsZero() bool {
 
 // Scan implements the Scanner interface.
 func (u *Uint32) Scan(value interface{}) error {
-	u.set = true
 	if value == nil {
-		u.Uint32, u.Valid = 0, false
+		u.Uint32, u.Valid, u.set = 0, false, false
 		return nil
 	}
-	u.Valid = true
+	u.Valid, u.set = true, true
 	return convert.ConvertAssign(&u.Uint32, value)
 }
 

--- a/uint32.go
+++ b/uint32.go
@@ -19,25 +19,25 @@ type Uint32 struct {
 }
 
 // NewUint32 creates a new Uint32
-func NewUint32(i uint32, valid, set bool) Uint32 {
+func NewUint32(i uint32, valid bool) Uint32 {
 	return Uint32{
 		Uint32: i,
 		Valid:  valid,
-		Set:    set,
+		Set:    true,
 	}
 }
 
 // Uint32From creates a new Uint32 that will always be valid.
 func Uint32From(i uint32) Uint32 {
-	return NewUint32(i, true, true)
+	return NewUint32(i, true)
 }
 
 // Uint32FromPtr creates a new Uint32 that be null if i is nil.
 func Uint32FromPtr(i *uint32) Uint32 {
 	if i == nil {
-		return NewUint32(0, false, true)
+		return NewUint32(0, false)
 	}
-	return NewUint32(*i, true, true)
+	return NewUint32(*i, true)
 }
 
 func (u Uint32) IsSet() bool {

--- a/uint32.go
+++ b/uint32.go
@@ -15,31 +15,38 @@ import (
 type Uint32 struct {
 	Uint32 uint32
 	Valid  bool
+	set    bool
 }
 
 // NewUint32 creates a new Uint32
-func NewUint32(i uint32, valid bool) Uint32 {
+func NewUint32(i uint32, valid, set bool) Uint32 {
 	return Uint32{
 		Uint32: i,
 		Valid:  valid,
+		set:    set,
 	}
 }
 
 // Uint32From creates a new Uint32 that will always be valid.
 func Uint32From(i uint32) Uint32 {
-	return NewUint32(i, true)
+	return NewUint32(i, true, true)
 }
 
 // Uint32FromPtr creates a new Uint32 that be null if i is nil.
 func Uint32FromPtr(i *uint32) Uint32 {
 	if i == nil {
-		return NewUint32(0, false)
+		return NewUint32(0, false, true)
 	}
-	return NewUint32(*i, true)
+	return NewUint32(*i, true, true)
+}
+
+func (u Uint32) IsSet() bool {
+	return u.set
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (u *Uint32) UnmarshalJSON(data []byte) error {
+	u.set = true
 	if bytes.Equal(data, NullBytes) {
 		u.Valid = false
 		u.Uint32 = 0

--- a/uint32.go
+++ b/uint32.go
@@ -15,7 +15,7 @@ import (
 type Uint32 struct {
 	Uint32 uint32
 	Valid  bool
-	set    bool
+	Set    bool
 }
 
 // NewUint32 creates a new Uint32
@@ -23,7 +23,7 @@ func NewUint32(i uint32, valid, set bool) Uint32 {
 	return Uint32{
 		Uint32: i,
 		Valid:  valid,
-		set:    set,
+		Set:    set,
 	}
 }
 
@@ -41,12 +41,12 @@ func Uint32FromPtr(i *uint32) Uint32 {
 }
 
 func (u Uint32) IsSet() bool {
-	return u.set
+	return u.Set
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (u *Uint32) UnmarshalJSON(data []byte) error {
-	u.set = true
+	u.Set = true
 	if bytes.Equal(data, NullBytes) {
 		u.Valid = false
 		u.Uint32 = 0
@@ -69,7 +69,7 @@ func (u *Uint32) UnmarshalJSON(data []byte) error {
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (u *Uint32) UnmarshalText(text []byte) error {
-	u.set = true
+	u.Set = true
 	if text == nil || len(text) == 0 {
 		u.Valid = false
 		return nil
@@ -103,7 +103,7 @@ func (u Uint32) MarshalText() ([]byte, error) {
 func (u *Uint32) SetValid(n uint32) {
 	u.Uint32 = n
 	u.Valid = true
-	u.set = true
+	u.Set = true
 }
 
 // Ptr returns a pointer to this Uint32's value, or a nil pointer if this Uint32 is null.
@@ -122,10 +122,10 @@ func (u Uint32) IsZero() bool {
 // Scan implements the Scanner interface.
 func (u *Uint32) Scan(value interface{}) error {
 	if value == nil {
-		u.Uint32, u.Valid, u.set = 0, false, false
+		u.Uint32, u.Valid, u.Set = 0, false, false
 		return nil
 	}
-	u.Valid, u.set = true, true
+	u.Valid, u.Set = true, true
 	return convert.ConvertAssign(&u.Uint32, value)
 }
 

--- a/uint32_test.go
+++ b/uint32_test.go
@@ -41,8 +41,8 @@ func TestUnmarshalUint32(t *testing.T) {
 	err = json.Unmarshal(nullJSON, &null)
 	maybePanic(err)
 	assertNullUint32(t, null, "null json")
-	if !null.set {
-		t.Error("should be set")
+	if !null.Set {
+		t.Error("should be Set")
 	}
 
 	var badType Uint32

--- a/uint32_test.go
+++ b/uint32_test.go
@@ -41,6 +41,9 @@ func TestUnmarshalUint32(t *testing.T) {
 	err = json.Unmarshal(nullJSON, &null)
 	maybePanic(err)
 	assertNullUint32(t, null, "null json")
+	if !null.set {
+		t.Error("should be set")
+	}
 
 	var badType Uint32
 	err = json.Unmarshal(boolJSON, &badType)
@@ -100,7 +103,7 @@ func TestMarshalUint32(t *testing.T) {
 	assertJSONEquals(t, data, "4294967294", "non-empty json marshal")
 
 	// invalid values should be encoded as null
-	null := NewUint32(0, false)
+	null := NewUint32(0, false, true)
 	data, err = json.Marshal(null)
 	maybePanic(err)
 	assertJSONEquals(t, data, "null", "null json marshal")
@@ -113,7 +116,7 @@ func TestMarshalUint32Text(t *testing.T) {
 	assertJSONEquals(t, data, "4294967294", "non-empty text marshal")
 
 	// invalid values should be encoded as null
-	null := NewUint32(0, false)
+	null := NewUint32(0, false, true)
 	data, err = null.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "null text marshal")
@@ -126,7 +129,7 @@ func TestUint32Pointer(t *testing.T) {
 		t.Errorf("bad %s uint32: %#v ≠ %d\n", "pointer", ptr, 4294967294)
 	}
 
-	null := NewUint32(0, false)
+	null := NewUint32(0, false, true)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s uint32: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -139,19 +142,19 @@ func TestUint32IsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	null := NewUint32(0, false)
+	null := NewUint32(0, false, true)
 	if !null.IsZero() {
 		t.Errorf("IsZero() should be true")
 	}
 
-	zero := NewUint32(0, true)
+	zero := NewUint32(0, true, true)
 	if zero.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
 }
 
 func TestUint32SetValid(t *testing.T) {
-	change := NewUint32(0, false)
+	change := NewUint32(0, false, true)
 	assertNullUint32(t, change, "SetValid()")
 	change.SetValid(4294967294)
 	assertUint32(t, change, "SetValid()")

--- a/uint32_test.go
+++ b/uint32_test.go
@@ -103,7 +103,7 @@ func TestMarshalUint32(t *testing.T) {
 	assertJSONEquals(t, data, "4294967294", "non-empty json marshal")
 
 	// invalid values should be encoded as null
-	null := NewUint32(0, false, true)
+	null := NewUint32(0, false)
 	data, err = json.Marshal(null)
 	maybePanic(err)
 	assertJSONEquals(t, data, "null", "null json marshal")
@@ -116,7 +116,7 @@ func TestMarshalUint32Text(t *testing.T) {
 	assertJSONEquals(t, data, "4294967294", "non-empty text marshal")
 
 	// invalid values should be encoded as null
-	null := NewUint32(0, false, true)
+	null := NewUint32(0, false)
 	data, err = null.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "null text marshal")
@@ -129,7 +129,7 @@ func TestUint32Pointer(t *testing.T) {
 		t.Errorf("bad %s uint32: %#v ≠ %d\n", "pointer", ptr, 4294967294)
 	}
 
-	null := NewUint32(0, false, true)
+	null := NewUint32(0, false)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s uint32: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -142,19 +142,19 @@ func TestUint32IsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	null := NewUint32(0, false, true)
+	null := NewUint32(0, false)
 	if !null.IsZero() {
 		t.Errorf("IsZero() should be true")
 	}
 
-	zero := NewUint32(0, true, true)
+	zero := NewUint32(0, true)
 	if zero.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
 }
 
 func TestUint32SetValid(t *testing.T) {
-	change := NewUint32(0, false, true)
+	change := NewUint32(0, false)
 	assertNullUint32(t, change, "SetValid()")
 	change.SetValid(4294967294)
 	assertUint32(t, change, "SetValid()")

--- a/uint64.go
+++ b/uint64.go
@@ -17,25 +17,25 @@ type Uint64 struct {
 }
 
 // NewUint64 creates a new Uint64
-func NewUint64(i uint64, valid, set bool) Uint64 {
+func NewUint64(i uint64, valid bool) Uint64 {
 	return Uint64{
 		Uint64: i,
 		Valid:  valid,
-		Set:    set,
+		Set:    true,
 	}
 }
 
 // Uint64From creates a new Uint64 that will always be valid.
 func Uint64From(i uint64) Uint64 {
-	return NewUint64(i, true, true)
+	return NewUint64(i, true)
 }
 
 // Uint64FromPtr creates a new Uint64 that be null if i is nil.
 func Uint64FromPtr(i *uint64) Uint64 {
 	if i == nil {
-		return NewUint64(0, false, true)
+		return NewUint64(0, false)
 	}
-	return NewUint64(*i, true, true)
+	return NewUint64(*i, true)
 }
 
 func (u Uint64) IsSet() bool {

--- a/uint64.go
+++ b/uint64.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"strconv"
 
-	"github.com/volatiletech/null/v8/convert"
+	"github.com/razor-1/null/v9/convert"
 )
 
 // Uint64 is an nullable uint64.
@@ -61,6 +61,7 @@ func (u *Uint64) UnmarshalJSON(data []byte) error {
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (u *Uint64) UnmarshalText(text []byte) error {
+	u.set = true
 	if text == nil || len(text) == 0 {
 		u.Valid = false
 		return nil
@@ -94,6 +95,7 @@ func (u Uint64) MarshalText() ([]byte, error) {
 func (u *Uint64) SetValid(n uint64) {
 	u.Uint64 = n
 	u.Valid = true
+	u.set = true
 }
 
 // Ptr returns a pointer to this Uint64's value, or a nil pointer if this Uint64 is null.
@@ -111,6 +113,7 @@ func (u Uint64) IsZero() bool {
 
 // Scan implements the Scanner interface.
 func (u *Uint64) Scan(value interface{}) error {
+	u.set = true
 	if value == nil {
 		u.Uint64, u.Valid = 0, false
 		return nil

--- a/uint64.go
+++ b/uint64.go
@@ -113,12 +113,11 @@ func (u Uint64) IsZero() bool {
 
 // Scan implements the Scanner interface.
 func (u *Uint64) Scan(value interface{}) error {
-	u.set = true
 	if value == nil {
-		u.Uint64, u.Valid = 0, false
+		u.Uint64, u.Valid, u.set = 0, false, false
 		return nil
 	}
-	u.Valid = true
+	u.Valid, u.set = true, true
 	return convert.ConvertAssign(&u.Uint64, value)
 }
 

--- a/uint64.go
+++ b/uint64.go
@@ -13,31 +13,38 @@ import (
 type Uint64 struct {
 	Uint64 uint64
 	Valid  bool
+	set    bool
 }
 
 // NewUint64 creates a new Uint64
-func NewUint64(i uint64, valid bool) Uint64 {
+func NewUint64(i uint64, valid, set bool) Uint64 {
 	return Uint64{
 		Uint64: i,
 		Valid:  valid,
+		set:    set,
 	}
 }
 
 // Uint64From creates a new Uint64 that will always be valid.
 func Uint64From(i uint64) Uint64 {
-	return NewUint64(i, true)
+	return NewUint64(i, true, true)
 }
 
 // Uint64FromPtr creates a new Uint64 that be null if i is nil.
 func Uint64FromPtr(i *uint64) Uint64 {
 	if i == nil {
-		return NewUint64(0, false)
+		return NewUint64(0, false, true)
 	}
-	return NewUint64(*i, true)
+	return NewUint64(*i, true, true)
+}
+
+func (u Uint64) IsSet() bool {
+	return u.set
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (u *Uint64) UnmarshalJSON(data []byte) error {
+	u.set = true
 	if bytes.Equal(data, NullBytes) {
 		u.Uint64 = 0
 		u.Valid = false

--- a/uint64.go
+++ b/uint64.go
@@ -13,7 +13,7 @@ import (
 type Uint64 struct {
 	Uint64 uint64
 	Valid  bool
-	set    bool
+	Set    bool
 }
 
 // NewUint64 creates a new Uint64
@@ -21,7 +21,7 @@ func NewUint64(i uint64, valid, set bool) Uint64 {
 	return Uint64{
 		Uint64: i,
 		Valid:  valid,
-		set:    set,
+		Set:    set,
 	}
 }
 
@@ -39,12 +39,12 @@ func Uint64FromPtr(i *uint64) Uint64 {
 }
 
 func (u Uint64) IsSet() bool {
-	return u.set
+	return u.Set
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (u *Uint64) UnmarshalJSON(data []byte) error {
-	u.set = true
+	u.Set = true
 	if bytes.Equal(data, NullBytes) {
 		u.Uint64 = 0
 		u.Valid = false
@@ -61,7 +61,7 @@ func (u *Uint64) UnmarshalJSON(data []byte) error {
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (u *Uint64) UnmarshalText(text []byte) error {
-	u.set = true
+	u.Set = true
 	if text == nil || len(text) == 0 {
 		u.Valid = false
 		return nil
@@ -95,7 +95,7 @@ func (u Uint64) MarshalText() ([]byte, error) {
 func (u *Uint64) SetValid(n uint64) {
 	u.Uint64 = n
 	u.Valid = true
-	u.set = true
+	u.Set = true
 }
 
 // Ptr returns a pointer to this Uint64's value, or a nil pointer if this Uint64 is null.
@@ -114,10 +114,10 @@ func (u Uint64) IsZero() bool {
 // Scan implements the Scanner interface.
 func (u *Uint64) Scan(value interface{}) error {
 	if value == nil {
-		u.Uint64, u.Valid, u.set = 0, false, false
+		u.Uint64, u.Valid, u.Set = 0, false, false
 		return nil
 	}
-	u.Valid, u.set = true, true
+	u.Valid, u.Set = true, true
 	return convert.ConvertAssign(&u.Uint64, value)
 }
 

--- a/uint64_test.go
+++ b/uint64_test.go
@@ -39,6 +39,9 @@ func TestUnmarshalUint64(t *testing.T) {
 	err = json.Unmarshal(nullJSON, &null)
 	maybePanic(err)
 	assertNullUint64(t, null, "null json")
+	if !null.set {
+		t.Error("should be set")
+	}
 
 	var badType Uint64
 	err = json.Unmarshal(boolJSON, &badType)
@@ -82,7 +85,7 @@ func TestMarshalUint64(t *testing.T) {
 	assertJSONEquals(t, data, "18446744073709551614", "non-empty json marshal")
 
 	// invalid values should be encoded as null
-	null := NewUint64(0, false)
+	null := NewUint64(0, false, true)
 	data, err = json.Marshal(null)
 	maybePanic(err)
 	assertJSONEquals(t, data, "null", "null json marshal")
@@ -95,7 +98,7 @@ func TestMarshalUint64Text(t *testing.T) {
 	assertJSONEquals(t, data, "18446744073709551614", "non-empty text marshal")
 
 	// invalid values should be encoded as null
-	null := NewUint64(0, false)
+	null := NewUint64(0, false, true)
 	data, err = null.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "null text marshal")
@@ -108,7 +111,7 @@ func TestUint64Pointer(t *testing.T) {
 		t.Errorf("bad %s uint64: %#v ≠ %d\n", "pointer", ptr, uint64(18446744073709551614))
 	}
 
-	null := NewUint64(0, false)
+	null := NewUint64(0, false, true)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s uint64: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -121,19 +124,19 @@ func TestUint64IsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	null := NewUint64(0, false)
+	null := NewUint64(0, false, true)
 	if !null.IsZero() {
 		t.Errorf("IsZero() should be true")
 	}
 
-	zero := NewUint64(0, true)
+	zero := NewUint64(0, true, true)
 	if zero.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
 }
 
 func TestUint64SetValid(t *testing.T) {
-	change := NewUint64(0, false)
+	change := NewUint64(0, false, true)
 	assertNullUint64(t, change, "SetValid()")
 	change.SetValid(18446744073709551614)
 	assertUint64(t, change, "SetValid()")

--- a/uint64_test.go
+++ b/uint64_test.go
@@ -39,8 +39,8 @@ func TestUnmarshalUint64(t *testing.T) {
 	err = json.Unmarshal(nullJSON, &null)
 	maybePanic(err)
 	assertNullUint64(t, null, "null json")
-	if !null.set {
-		t.Error("should be set")
+	if !null.Set {
+		t.Error("should be Set")
 	}
 
 	var badType Uint64

--- a/uint64_test.go
+++ b/uint64_test.go
@@ -85,7 +85,7 @@ func TestMarshalUint64(t *testing.T) {
 	assertJSONEquals(t, data, "18446744073709551614", "non-empty json marshal")
 
 	// invalid values should be encoded as null
-	null := NewUint64(0, false, true)
+	null := NewUint64(0, false)
 	data, err = json.Marshal(null)
 	maybePanic(err)
 	assertJSONEquals(t, data, "null", "null json marshal")
@@ -98,7 +98,7 @@ func TestMarshalUint64Text(t *testing.T) {
 	assertJSONEquals(t, data, "18446744073709551614", "non-empty text marshal")
 
 	// invalid values should be encoded as null
-	null := NewUint64(0, false, true)
+	null := NewUint64(0, false)
 	data, err = null.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "null text marshal")
@@ -111,7 +111,7 @@ func TestUint64Pointer(t *testing.T) {
 		t.Errorf("bad %s uint64: %#v ≠ %d\n", "pointer", ptr, uint64(18446744073709551614))
 	}
 
-	null := NewUint64(0, false, true)
+	null := NewUint64(0, false)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s uint64: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -124,19 +124,19 @@ func TestUint64IsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	null := NewUint64(0, false, true)
+	null := NewUint64(0, false)
 	if !null.IsZero() {
 		t.Errorf("IsZero() should be true")
 	}
 
-	zero := NewUint64(0, true, true)
+	zero := NewUint64(0, true)
 	if zero.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
 }
 
 func TestUint64SetValid(t *testing.T) {
-	change := NewUint64(0, false, true)
+	change := NewUint64(0, false)
 	assertNullUint64(t, change, "SetValid()")
 	change.SetValid(18446744073709551614)
 	assertUint64(t, change, "SetValid()")

--- a/uint8.go
+++ b/uint8.go
@@ -15,7 +15,7 @@ import (
 type Uint8 struct {
 	Uint8 uint8
 	Valid bool
-	set   bool
+	Set   bool
 }
 
 // NewUint8 creates a new Uint8
@@ -23,7 +23,7 @@ func NewUint8(i uint8, valid, set bool) Uint8 {
 	return Uint8{
 		Uint8: i,
 		Valid: valid,
-		set:   set,
+		Set:   set,
 	}
 }
 
@@ -41,12 +41,12 @@ func Uint8FromPtr(i *uint8) Uint8 {
 }
 
 func (u Uint8) IsSet() bool {
-	return u.set
+	return u.Set
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (u *Uint8) UnmarshalJSON(data []byte) error {
-	u.set = true
+	u.Set = true
 	if bytes.Equal(data, NullBytes) {
 		u.Valid = false
 		u.Uint8 = 0
@@ -69,7 +69,7 @@ func (u *Uint8) UnmarshalJSON(data []byte) error {
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (u *Uint8) UnmarshalText(text []byte) error {
-	u.set = true
+	u.Set = true
 	if text == nil || len(text) == 0 {
 		u.Valid = false
 		return nil
@@ -103,7 +103,7 @@ func (u Uint8) MarshalText() ([]byte, error) {
 func (u *Uint8) SetValid(n uint8) {
 	u.Uint8 = n
 	u.Valid = true
-	u.set = true
+	u.Set = true
 }
 
 // Ptr returns a pointer to this Uint8's value, or a nil pointer if this Uint8 is null.
@@ -122,10 +122,10 @@ func (u Uint8) IsZero() bool {
 // Scan implements the Scanner interface.
 func (u *Uint8) Scan(value interface{}) error {
 	if value == nil {
-		u.Uint8, u.Valid, u.set = 0, false, false
+		u.Uint8, u.Valid, u.Set = 0, false, false
 		return nil
 	}
-	u.Valid, u.set = true, true
+	u.Valid, u.Set = true, true
 	return convert.ConvertAssign(&u.Uint8, value)
 }
 

--- a/uint8.go
+++ b/uint8.go
@@ -8,7 +8,7 @@ import (
 	"math"
 	"strconv"
 
-	"github.com/volatiletech/null/v8/convert"
+	"github.com/razor-1/null/v9/convert"
 )
 
 // Uint8 is an nullable uint8.
@@ -69,6 +69,7 @@ func (u *Uint8) UnmarshalJSON(data []byte) error {
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (u *Uint8) UnmarshalText(text []byte) error {
+	u.set = true
 	if text == nil || len(text) == 0 {
 		u.Valid = false
 		return nil
@@ -102,6 +103,7 @@ func (u Uint8) MarshalText() ([]byte, error) {
 func (u *Uint8) SetValid(n uint8) {
 	u.Uint8 = n
 	u.Valid = true
+	u.set = true
 }
 
 // Ptr returns a pointer to this Uint8's value, or a nil pointer if this Uint8 is null.
@@ -119,6 +121,7 @@ func (u Uint8) IsZero() bool {
 
 // Scan implements the Scanner interface.
 func (u *Uint8) Scan(value interface{}) error {
+	u.set = true
 	if value == nil {
 		u.Uint8, u.Valid = 0, false
 		return nil

--- a/uint8.go
+++ b/uint8.go
@@ -19,25 +19,25 @@ type Uint8 struct {
 }
 
 // NewUint8 creates a new Uint8
-func NewUint8(i uint8, valid, set bool) Uint8 {
+func NewUint8(i uint8, valid bool) Uint8 {
 	return Uint8{
 		Uint8: i,
 		Valid: valid,
-		Set:   set,
+		Set:   true,
 	}
 }
 
 // Uint8From creates a new Uint8 that will always be valid.
 func Uint8From(i uint8) Uint8 {
-	return NewUint8(i, true, true)
+	return NewUint8(i, true)
 }
 
 // Uint8FromPtr creates a new Uint8 that be null if i is nil.
 func Uint8FromPtr(i *uint8) Uint8 {
 	if i == nil {
-		return NewUint8(0, false, true)
+		return NewUint8(0, false)
 	}
-	return NewUint8(*i, true, true)
+	return NewUint8(*i, true)
 }
 
 func (u Uint8) IsSet() bool {

--- a/uint8.go
+++ b/uint8.go
@@ -15,31 +15,38 @@ import (
 type Uint8 struct {
 	Uint8 uint8
 	Valid bool
+	set   bool
 }
 
 // NewUint8 creates a new Uint8
-func NewUint8(i uint8, valid bool) Uint8 {
+func NewUint8(i uint8, valid, set bool) Uint8 {
 	return Uint8{
 		Uint8: i,
 		Valid: valid,
+		set:   set,
 	}
 }
 
 // Uint8From creates a new Uint8 that will always be valid.
 func Uint8From(i uint8) Uint8 {
-	return NewUint8(i, true)
+	return NewUint8(i, true, true)
 }
 
 // Uint8FromPtr creates a new Uint8 that be null if i is nil.
 func Uint8FromPtr(i *uint8) Uint8 {
 	if i == nil {
-		return NewUint8(0, false)
+		return NewUint8(0, false, true)
 	}
-	return NewUint8(*i, true)
+	return NewUint8(*i, true, true)
+}
+
+func (u Uint8) IsSet() bool {
+	return u.set
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (u *Uint8) UnmarshalJSON(data []byte) error {
+	u.set = true
 	if bytes.Equal(data, NullBytes) {
 		u.Valid = false
 		u.Uint8 = 0

--- a/uint8.go
+++ b/uint8.go
@@ -121,12 +121,11 @@ func (u Uint8) IsZero() bool {
 
 // Scan implements the Scanner interface.
 func (u *Uint8) Scan(value interface{}) error {
-	u.set = true
 	if value == nil {
-		u.Uint8, u.Valid = 0, false
+		u.Uint8, u.Valid, u.set = 0, false, false
 		return nil
 	}
-	u.Valid = true
+	u.Valid, u.set = true, true
 	return convert.ConvertAssign(&u.Uint8, value)
 }
 

--- a/uint8_test.go
+++ b/uint8_test.go
@@ -103,7 +103,7 @@ func TestMarshalUint8(t *testing.T) {
 	assertJSONEquals(t, data, "254", "non-empty json marshal")
 
 	// invalid values should be encoded as null
-	null := NewUint8(0, false, true)
+	null := NewUint8(0, false)
 	data, err = json.Marshal(null)
 	maybePanic(err)
 	assertJSONEquals(t, data, "null", "null json marshal")
@@ -116,7 +116,7 @@ func TestMarshalUint8Text(t *testing.T) {
 	assertJSONEquals(t, data, "254", "non-empty text marshal")
 
 	// invalid values should be encoded as null
-	null := NewUint8(0, false, true)
+	null := NewUint8(0, false)
 	data, err = null.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "null text marshal")
@@ -129,7 +129,7 @@ func TestUint8Pointer(t *testing.T) {
 		t.Errorf("bad %s uint8: %#v ≠ %d\n", "pointer", ptr, 254)
 	}
 
-	null := NewUint8(0, false, true)
+	null := NewUint8(0, false)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s uint8: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -142,19 +142,19 @@ func TestUint8IsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	null := NewUint8(0, false, true)
+	null := NewUint8(0, false)
 	if !null.IsZero() {
 		t.Errorf("IsZero() should be true")
 	}
 
-	zero := NewUint8(0, true, true)
+	zero := NewUint8(0, true)
 	if zero.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
 }
 
 func TestUint8SetValid(t *testing.T) {
-	change := NewUint8(0, false, true)
+	change := NewUint8(0, false)
 	assertNullUint8(t, change, "SetValid()")
 	change.SetValid(254)
 	assertUint8(t, change, "SetValid()")

--- a/uint8_test.go
+++ b/uint8_test.go
@@ -41,8 +41,8 @@ func TestUnmarshalUint8(t *testing.T) {
 	err = json.Unmarshal(nullJSON, &null)
 	maybePanic(err)
 	assertNullUint8(t, null, "null json")
-	if !null.set {
-		t.Error("should be set")
+	if !null.Set {
+		t.Error("should be Set")
 	}
 
 	var badType Uint8

--- a/uint8_test.go
+++ b/uint8_test.go
@@ -41,6 +41,9 @@ func TestUnmarshalUint8(t *testing.T) {
 	err = json.Unmarshal(nullJSON, &null)
 	maybePanic(err)
 	assertNullUint8(t, null, "null json")
+	if !null.set {
+		t.Error("should be set")
+	}
 
 	var badType Uint8
 	err = json.Unmarshal(boolJSON, &badType)
@@ -100,7 +103,7 @@ func TestMarshalUint8(t *testing.T) {
 	assertJSONEquals(t, data, "254", "non-empty json marshal")
 
 	// invalid values should be encoded as null
-	null := NewUint8(0, false)
+	null := NewUint8(0, false, true)
 	data, err = json.Marshal(null)
 	maybePanic(err)
 	assertJSONEquals(t, data, "null", "null json marshal")
@@ -113,7 +116,7 @@ func TestMarshalUint8Text(t *testing.T) {
 	assertJSONEquals(t, data, "254", "non-empty text marshal")
 
 	// invalid values should be encoded as null
-	null := NewUint8(0, false)
+	null := NewUint8(0, false, true)
 	data, err = null.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "null text marshal")
@@ -126,7 +129,7 @@ func TestUint8Pointer(t *testing.T) {
 		t.Errorf("bad %s uint8: %#v ≠ %d\n", "pointer", ptr, 254)
 	}
 
-	null := NewUint8(0, false)
+	null := NewUint8(0, false, true)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s uint8: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -139,19 +142,19 @@ func TestUint8IsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	null := NewUint8(0, false)
+	null := NewUint8(0, false, true)
 	if !null.IsZero() {
 		t.Errorf("IsZero() should be true")
 	}
 
-	zero := NewUint8(0, true)
+	zero := NewUint8(0, true, true)
 	if zero.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
 }
 
 func TestUint8SetValid(t *testing.T) {
-	change := NewUint8(0, false)
+	change := NewUint8(0, false, true)
 	assertNullUint8(t, change, "SetValid()")
 	change.SetValid(254)
 	assertUint8(t, change, "SetValid()")

--- a/uint_test.go
+++ b/uint_test.go
@@ -85,7 +85,7 @@ func TestMarshalUint(t *testing.T) {
 	assertJSONEquals(t, data, "12345", "non-empty json marshal")
 
 	// invalid values should be encoded as null
-	null := NewUint(0, false, true)
+	null := NewUint(0, false)
 	data, err = json.Marshal(null)
 	maybePanic(err)
 	assertJSONEquals(t, data, "null", "null json marshal")
@@ -98,7 +98,7 @@ func TestMarshalUintText(t *testing.T) {
 	assertJSONEquals(t, data, "12345", "non-empty text marshal")
 
 	// invalid values should be encoded as null
-	null := NewUint(0, false, true)
+	null := NewUint(0, false)
 	data, err = null.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "null text marshal")
@@ -111,7 +111,7 @@ func TestUintPointer(t *testing.T) {
 		t.Errorf("bad %s uint: %#v ≠ %d\n", "pointer", ptr, 12345)
 	}
 
-	null := NewUint(0, false, true)
+	null := NewUint(0, false)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s uint: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -124,19 +124,19 @@ func TestUintIsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	null := NewUint(0, false, true)
+	null := NewUint(0, false)
 	if !null.IsZero() {
 		t.Errorf("IsZero() should be true")
 	}
 
-	zero := NewUint(0, true, true)
+	zero := NewUint(0, true)
 	if zero.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
 }
 
 func TestUintSetValid(t *testing.T) {
-	change := NewUint(0, false, true)
+	change := NewUint(0, false)
 	assertNullUint(t, change, "SetValid()")
 	change.SetValid(12345)
 	assertUint(t, change, "SetValid()")

--- a/uint_test.go
+++ b/uint_test.go
@@ -39,6 +39,9 @@ func TestUnmarshalUint(t *testing.T) {
 	err = json.Unmarshal(nullJSON, &null)
 	maybePanic(err)
 	assertNullUint(t, null, "null json")
+	if !null.set {
+		t.Error("should be set")
+	}
 
 	var badType Uint
 	err = json.Unmarshal(boolJSON, &badType)
@@ -82,7 +85,7 @@ func TestMarshalUint(t *testing.T) {
 	assertJSONEquals(t, data, "12345", "non-empty json marshal")
 
 	// invalid values should be encoded as null
-	null := NewUint(0, false)
+	null := NewUint(0, false, true)
 	data, err = json.Marshal(null)
 	maybePanic(err)
 	assertJSONEquals(t, data, "null", "null json marshal")
@@ -95,7 +98,7 @@ func TestMarshalUintText(t *testing.T) {
 	assertJSONEquals(t, data, "12345", "non-empty text marshal")
 
 	// invalid values should be encoded as null
-	null := NewUint(0, false)
+	null := NewUint(0, false, true)
 	data, err = null.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "null text marshal")
@@ -108,7 +111,7 @@ func TestUintPointer(t *testing.T) {
 		t.Errorf("bad %s uint: %#v ≠ %d\n", "pointer", ptr, 12345)
 	}
 
-	null := NewUint(0, false)
+	null := NewUint(0, false, true)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s uint: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -121,19 +124,19 @@ func TestUintIsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	null := NewUint(0, false)
+	null := NewUint(0, false, true)
 	if !null.IsZero() {
 		t.Errorf("IsZero() should be true")
 	}
 
-	zero := NewUint(0, true)
+	zero := NewUint(0, true, true)
 	if zero.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
 }
 
 func TestUintSetValid(t *testing.T) {
-	change := NewUint(0, false)
+	change := NewUint(0, false, true)
 	assertNullUint(t, change, "SetValid()")
 	change.SetValid(12345)
 	assertUint(t, change, "SetValid()")

--- a/uint_test.go
+++ b/uint_test.go
@@ -39,8 +39,8 @@ func TestUnmarshalUint(t *testing.T) {
 	err = json.Unmarshal(nullJSON, &null)
 	maybePanic(err)
 	assertNullUint(t, null, "null json")
-	if !null.set {
-		t.Error("should be set")
+	if !null.Set {
+		t.Error("should be Set")
 	}
 
 	var badType Uint


### PR DESCRIPTION
Inspired by https://www.calhoun.io/how-to-determine-if-a-json-key-has-been-set-to-null-or-not-provided/, allow the user to know not just if something is null, but whether the key was sent in JSON at all. Critical for PATCH and other use cases.