### PR TITLE
Fix Uint64.Scan() to convert negative int64 to uint64

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
+github.com/friendsofgo/errors v0.9.2 h1:X6NYxef4efCBdwI7BgS820zFaN7Cphrmb+Pljdzjtgk=
 github.com/friendsofgo/errors v0.9.2/go.mod h1:yCvFW5AkDIL9qn7suHVLiI/gH228n7PC4Pn44IGoTOI=
+github.com/gofrs/uuid v3.2.0+incompatible h1:y12jRkkFxsd7GpqdSZ+/KCs/fJbqpEXSGd4+jfEaewE=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/volatiletech/inflect v0.0.1 h1:2a6FcMQyhmPZcLa+uet3VJ8gLn/9svWhJxJYwvE8KsU=
 github.com/volatiletech/inflect v0.0.1/go.mod h1:IBti31tG6phkHitLlr5j7shC5SOo//x0AjDzaJU1PLA=

--- a/uint64.go
+++ b/uint64.go
@@ -124,6 +124,7 @@ func (u Uint64) Value() (driver.Value, error) {
 		return nil, nil
 	}
 
+	// If u.Uint64 overflows the range of int64, convert it to string
 	if u.Uint64 >= 1<<63 {
 		return strconv.FormatUint(u.Uint64, 10), nil
 	}

--- a/uint64.go
+++ b/uint64.go
@@ -109,6 +109,12 @@ func (u *Uint64) Scan(value interface{}) error {
 		return nil
 	}
 	u.Valid = true
+
+	// If value is negative int64, convert it to uint64
+	if i, ok := value.(int64); ok && i < 0 {
+		return convert.ConvertAssign(&u.Uint64, uint64(i))
+	}
+
 	return convert.ConvertAssign(&u.Uint64, value)
 }
 

--- a/uint64_test.go
+++ b/uint64_test.go
@@ -145,10 +145,13 @@ func TestUint64Scan(t *testing.T) {
 	maybePanic(err)
 	assertUint64(t, i, "scanned uint64")
 
-	var null Uint64
-	err = null.Scan(nil)
+	err = i.Scan(int64(-2))
 	maybePanic(err)
-	assertNullUint64(t, null, "scanned null")
+	assertUint64(t, i, "scanned int64")
+
+	err = i.Scan(nil)
+	maybePanic(err)
+	assertNullUint64(t, i, "scanned null")
 }
 
 func assertUint64(t *testing.T, i Uint64, from string) {


### PR DESCRIPTION
As described in https://github.com/volatiletech/sqlboiler/issues/905, sqlboiler converts `uint64` to `int64` in relation-methods. So I've fixed `Uint64.Scan()` to convert received `int64` to `uint64` when it is smaller than 0.

Also, I've done some works that aren't related to the issue directly.

- Add a comment to the fix introduced in https://github.com/volatiletech/null/pull/8 for clarification
- Updated go.sum
  - It's been updated when I ran `go mod tidy`
  - I think these lines should be committed to the repository, for cache verification
    - cf. https://golang.org/ref/mod#go